### PR TITLE
Make RPC socket available outside sandbox

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -18,6 +18,7 @@
       "--filesystem=xdg-videos:ro",
       "--filesystem=xdg-pictures:ro",
       "--filesystem=xdg-download",
+      "--filesystem=xdg-run/discord:create",
       "--env=XDG_CURRENT_DESKTOP=Unity",
       "--talk-name=org.kde.StatusNotifierWatcher"
   ],
@@ -27,7 +28,7 @@
       "buildsystem": "simple",
       "build-commands": [
         "install -D apply_extra /app/bin/apply_extra",
-        "install -D discord /app/bin/discord",
+        "install -D discord.sh /app/bin/discord",
         "install -Dm644 com.discordapp.Discord.appdata.xml /app/share/appdata/com.discordapp.Discord.appdata.xml"
       ],
       "sources": [
@@ -53,11 +54,8 @@
           ]
         },
         {
-          "type": "script",
-          "dest-filename": "discord",
-          "commands": [
-            "exec env TMPDIR=$XDG_CACHE_HOME /app/extra/discord \"$@\""
-          ]
+          "type": "file",
+          "path": "discord.sh"
         },
         {
           "type": "file",
@@ -110,6 +108,16 @@
               "type": "archive",
               "url": "https://github.com/pciutils/pciutils/archive/v3.5.5.tar.gz",
               "sha256": "07b9959d929248eeb274d8e8f7df33e2173f7eb7d49328a70366071f569fbade"
+            }
+          ]
+        },
+        {
+          "name": "socat",
+          "sources": [
+            {
+              "type": "archive",
+              "url": "http://www.dest-unreach.org/socat/download/socat-1.7.3.2.tar.gz",
+              "sha256": "ce3efc17e3e544876ebce7cd6c85b3c279fda057b2857fcaaf67b9ab8bdaf034"
             }
           ]
         }

--- a/discord.sh
+++ b/discord.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-socat -d -d -d -v \
+socat $SOCAT_ARGS \
     UNIX-LISTEN:$XDG_RUNTIME_DIR/discord/ipc-0,forever,fork \
     UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
     &

--- a/discord.sh
+++ b/discord.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+socat -d -d -d -v \
+    UNIX-LISTEN:$XDG_RUNTIME_DIR/discord/ipc-0,forever,fork \
+    UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
+    &
+socat_pid=$!
+env TMPDIR=$XDG_CACHE_HOME /app/extra/discord "$@"
+kill -SIGTERM $socat_pid


### PR DESCRIPTION
We can use `socat` to "proxy" the socket and make it available to host (and possibly other apps) under path `$XDG_RUNTIME_DIR/discord/rpc-0` (instead of `$XDG_RUNTIME_DIR/discord-rpc-0`).
To use it, user would need to create an apropriate symlink.