### PR TITLE
Update base app to Electron2

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.discordapp.Discord",
   "branch": "stable",
-  "base": "io.atom.electron.BaseApp",
+  "base": "org.electronjs.Electron2.BaseApp",
   "base-version": "18.08",
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "18.08",


### PR DESCRIPTION
Fixes tray icons, which aren't working because updated Discord wants GTK3 libappindicator, not GTK2.