### PR TITLE
Relocate RP socket to xdg-run/app/appid directory

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -14,7 +14,7 @@
   <screenshots>
     <screenshot type="default">
       <image type="source">https://support.discordapp.com/hc/en-us/article_attachments/206368357/MenuCircle.png</image>
-      <caption>Window</caption>
+      <caption>Main window</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://support.discordapp.com/hc/en-us/article_attachments/206077828/FLFeathWindow.png</image>

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -18,7 +18,6 @@
       "--filesystem=xdg-videos:ro",
       "--filesystem=xdg-pictures:ro",
       "--filesystem=xdg-download",
-      "--filesystem=xdg-run/discord:create",
       "--env=XDG_CURRENT_DESKTOP=Unity",
       "--talk-name=org.freedesktop.portal.Fcitx",
       "--talk-name=org.kde.StatusNotifierWatcher"

--- a/discord.sh
+++ b/discord.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+FLATPAK_ID=${FLATPAK_ID:-"com.discordapp.Discord"}
 socat $SOCAT_ARGS \
-    UNIX-LISTEN:$XDG_RUNTIME_DIR/discord/ipc-0,forever,fork \
+    UNIX-LISTEN:$XDG_RUNTIME_DIR/app/${FLATPAK_ID}/discord-ipc-0,forever,fork \
     UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
     &
 socat_pid=$!


### PR DESCRIPTION
Change socket location from `$XDG_RUNTIME_DIR/discord/ipc-0` to `$XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0`.
This way the exported Discord RPC socket would keep it's original name (`discord-ipc-0`) and the already-existing `xdg-run/app/appid` directory would be reused.
KeePassXC takes similar approach: it puts socket under `xdg-run/app/appid`, I find it much better than the original approach I took for Discord.

Apps that would need changes:
- [ ] flathub/org.DolphinEmu.dolphin-emu#39
- [ ] flathub/com.valvesoftware.Steam#273
- [ ] flathub/com.googleplaymusicdesktopplayer.GPMDP#12