### PR TITLE
Fix appdata validation

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -14,7 +14,7 @@
   <screenshots>
     <screenshot type="default">
       <image type="source">https://support.discordapp.com/hc/en-us/article_attachments/206368357/MenuCircle.png</image>
-      <caption>Window</caption>
+      <caption>Main window</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://support.discordapp.com/hc/en-us/article_attachments/206077828/FLFeathWindow.png</image>


### PR DESCRIPTION
```
builddir/files/share/appdata/com.discordapp.Discord.appdata.xml: FAILED:
• style-invalid         : <caption> is too short [Window];shortest allowed is 10 chars
```