### PR TITLE
Use dark titlebar if dark mode is enabled

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -27,10 +27,35 @@
   ],
   "modules": [
     {
+      "name": "xprop",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://xorg.freedesktop.org/archive/individual/app/xprop-1.2.4.tar.bz2",
+          "sha256": "8c77fb096e46c60032b7e2bde9492c3ffcc18734f50b395085a5f10bfd3cf753"
+        }
+      ]
+    },
+    {
+      "name": "python3-XLib",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} XLib"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/3f/00/321541273b0ed2167b36c82be9baeb0bdc8af1c11c1b01de9436b84b5eaf/xlib-0.21-py2.py3-none-any.whl",
+          "sha256": "8eee67dad83ef4b82bbbfa85d51eeb20c79d12b119fe25aa1d27bd602ff82212"
+        }
+      ]
+    },
+    {
       "name": "discord",
       "buildsystem": "simple",
       "build-commands": [
         "install -Dm755 discord.sh /app/bin/discord",
+        "install -Dm755 set-gtk-dark-theme.py /app/bin",
         "mv Discord /app/discord",
         "chmod +x /app/discord/Discord",
         "install -d /app/share/applications",
@@ -57,6 +82,10 @@
         {
           "type": "file",
           "path": "com.discordapp.Discord.appdata.xml"
+        },
+        {
+          "type": "file",
+          "path": "set-gtk-dark-theme.py"
         }
       ],
       "modules": [

--- a/discord.sh
+++ b/discord.sh
@@ -5,5 +5,6 @@ socat $SOCAT_ARGS \
     UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
     &
 socat_pid=$!
+set-gtk-dark-theme.py &
 env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord "$@"
 kill -SIGTERM $socat_pid

--- a/set-gtk-dark-theme.py
+++ b/set-gtk-dark-theme.py
@@ -152,11 +152,18 @@ if __name__ == "__main__":
     xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
         os.path.expanduser("~"), ".config"
     )
-    with open(
-        os.path.join(xdg_config_home, "discord", "settings.json"),
-        "r",
-    ) as settings_file:
-        # Read config file and set the dark titlebar if dark theme is enabled
-        settings = json.load(settings_file)
-        if settings["BACKGROUND_COLOR"] == "#202225":
-            main()
+    try:
+        with open(
+            os.path.join(xdg_config_home, "discord", "settings.json"),
+            "r",
+        ) as settings_file:
+            # Read config file and set the dark titlebar if dark theme is enabled
+            settings = json.load(settings_file)
+            if settings["BACKGROUND_COLOR"] == "#202225":
+                main()
+    except OSError as e:
+        print(f"Error opening settings.json: {e}")
+    except json.decoder.JSONDecodeError as e:
+        print(f"Error reading settings.json: {e}")
+    except KeyError as e:
+        print(f"Error reading dictionary property: {e}")

--- a/set-gtk-dark-theme.py
+++ b/set-gtk-dark-theme.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Set the GTK titlebar to dark if dark theme is selected in Discord.
+
+Modified from
+https://github.com/flathub/com.spotify.Client/blob/master/set-dark-theme-variant.py
+"""
+
+import json
+import os
+import subprocess
+import time
+import Xlib.display
+import Xlib.error
+import Xlib.X
+
+disp = Xlib.display.Display()
+root = disp.screen().root
+
+NET_CLIENT_LIST = disp.intern_atom("_NET_CLIENT_LIST")
+NET_WM_NAME = disp.intern_atom("_NET_WM_NAME")  # UTF-8
+WM_NAME = disp.intern_atom("WM_NAME")  # Legacy encoding
+
+
+# Copied from https://gist.github.com/ssokolow/e7c9aae63fb7973e4d64cff969a78ae8
+def _get_window_name_inner(win_obj):
+    # Attempts to get the UTF-8 or legacy window name
+    for atom in (NET_WM_NAME, WM_NAME):
+        try:
+            window_name = win_obj.get_full_property(atom, Xlib.X.AnyPropertyType)
+        except UnicodeDecodeError:  # Apparently a Debian distro package bug
+            return None
+        else:
+            if window_name:
+                win_name = window_name.value
+                if isinstance(win_name, bytes):
+                    # Apparently COMPOUND_TEXT is so arcane that this is how
+                    # tools like xprop deal with receiving it these days
+                    win_name = win_name.decode("latin1", "replace")
+                return win_name
+        return None
+
+
+def set_theme_variant(window_titles, window_classes, variant):
+    # Loop though all of the windows and look for one that matches one
+    # of the possible window titles.
+    win_ids = root.get_full_property(NET_CLIENT_LIST, Xlib.X.AnyPropertyType)
+    if win_ids:
+        win_ids = win_ids.value
+        for win_id in win_ids:
+            try:
+                win = disp.create_resource_object("window", win_id)
+                # We don't care about dialog windows
+                # and the likes.
+                if not win.get_wm_transient_for():
+                    win_name = _get_window_name_inner(win)
+                    win_class = win.get_wm_class()
+                    # Only set the theme variant if the following are true:
+                    # 1. X window name contains one of the window titles
+                    # 2. Window is not the Discord Updater pop-up
+                    # 3. X window classes list contains any one of the window classes
+                    #    (i.e. the classes match)
+                    if (
+                        win_name
+                        and any([title in win_name for title in window_titles])
+                        and win_name != "Discord Updater"
+                        and win_class
+                        and not set(win_class).isdisjoint(window_classes)
+                    ):
+                        return set_theme_variant_by_window_id(win_id, variant)
+            except Xlib.error.BadWindow:
+                pass
+    return False
+
+
+def set_theme_variant_by_window_id(window_id, variant):
+    # Pretty self explanatory. Use subprocess to call
+    # xprop and set the variant.
+    output = subprocess.run(
+        [
+            "xprop",
+            "-id",
+            str(window_id),
+            "-f",
+            "_GTK_THEME_VARIANT",
+            "8u",
+            "-set",
+            "_GTK_THEME_VARIANT",
+            variant,
+        ]
+    )
+    return output.returncode == 0
+
+
+def set_theme_variant_by_window_title(title, variant):
+    # Pretty self explanatory. Use subprocess to call
+    # xprop and set the variant.
+    output = subprocess.run(
+        [
+            "xprop",
+            "-name",
+            title,
+            "-f",
+            "_GTK_THEME_VARIANT",
+            "8u",
+            "-set",
+            "_GTK_THEME_VARIANT",
+            variant,
+        ]
+    )
+    return output.returncode == 0
+
+
+def fallback(window_titles, variant):
+    # In the event that the
+    # window we were looking for
+    # doesn't show up in a timely manner
+    # fallback to blindly trying to set
+    # the variant.
+    for title in window_titles:
+        set_theme_variant_by_window_title(title, variant)
+
+
+def main():
+    start = time.time()
+    # Listen for X Property Change events.
+    root.change_attributes(event_mask=Xlib.X.PropertyChangeMask)
+    window_titles = window_classes = ("Discord", "discord")
+    variant = "dark"
+    # In the unlikely event that our window shows up before
+    # the script starts don't start a while loop.
+    if not set_theme_variant(window_titles, window_classes, variant):
+        # Basically give our window 5 secs to show up.
+        # If it doesn't just fallback to the old way of blindly
+        # trying to set the theme variant
+        while True:
+            if time.time() - start <= 5:
+                # disp.next_event() blocks if no events are
+                # queued. In combination with while True
+                # it creates a very simple event loop.
+                disp.next_event()
+                # We only try to set the variant after
+                # there has been a Property Change event.
+                if set_theme_variant(window_titles, window_classes, variant):
+                    break
+            else:
+                fallback(window_titles, variant)
+                break
+
+
+if __name__ == "__main__":
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+        os.path.expanduser("~"), ".config"
+    )
+    with open(
+        os.path.join(xdg_config_home, "discord", "settings.json"),
+        "r",
+    ) as settings_file:
+        # Read config file and set the dark titlebar if dark theme is enabled
+        settings = json.load(settings_file)
+        if settings["BACKGROUND_COLOR"] == "#202225":
+            main()


### PR DESCRIPTION
 Fixes #90 

Based on the [script used by the Spotify flatpak](https://github.com/flathub/com.spotify.Client/blob/master/set-dark-theme-variant.py).

Runs a python script in the background when launching Discord. The script sets a dark titlebar if the Discord config `BACKGROUND_COLOR` is `#202255`. (see https://github.com/flathub/com.discordapp.Discord/issues/90#issuecomment-695822104). The script will attempt to set the titlebar color for 5 seconds, and defaults to a fallback if it fails to do so within that timeframe. 

Limitation: because the script is only run on app startup, the titlebar theme will not be updated until the app is restarted