### PR TITLE
Emoji fix

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -27,6 +27,28 @@
     ],
     "modules": [
         {
+        "name": "twemoji-fonts",
+        "buildsystem":"simple",
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://github.com/eosrei/twemoji-color-font/releases/download/v13.0.1/TwitterColorEmoji-SVGinOT-Linux-13.0.1.tar.gz",
+                "sha256": "7655b0989d12e6138f40274e6343c29d2f9bc85c48251d504418eca1cc62c2d6"
+            },
+            {
+                "type": "file",
+                "path": "emoji-font.conf"
+            }
+        ],
+        "build-commands": [
+            "mkdir -p /app/share/fonts/",
+            "cp TwitterColorEmoji-SVGinOT.ttf /app/share/fonts/",
+            "mkdir -p /app/etc/fonts/",
+            "cp emoji-font.conf /app/etc/fonts/local.conf",
+            "fc-cache -fv"
+        ]
+        },
+        {
             "name": "xprop",
             "sources": [
                 {

--- a/emoji-font.conf
+++ b/emoji-font.conf
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+<description>Emoji fix</description>
+<!-- Priority:
+ ! 1. The generic family OR specific family
+ ! 2. The emoji font family (defined in 60-generic.conf)
+ ! 3. All the rest
+ !-->
+
+    <alias binding="weak">
+        <family>sans-serif</family>
+        <prefer>
+            <family>emoji</family>
+        </prefer>
+    </alias>
+
+    <alias binding="weak">
+        <family>serif</family>
+        <prefer>
+            <family>emoji</family>
+        </prefer>
+    </alias>
+
+    <alias binding="weak">
+        <family>monospace</family>
+        <prefer>
+            <family>emoji</family>
+        </prefer>
+    </alias>
+</fontconfig>


### PR DESCRIPTION
This finally addresses #106 by bundling twemoji with the flatpak, and setting it in `/app/etc/fonts/local.conf`. Rationale for using twemoji in particular is that Discord converts all unicode emojis to images in messages, and twemoji is what they use for those images. This will ensure emoji consistency everywhere with the exception of the system window title bar, which is imho out of the scope here.