### PR TITLE
Disable breaking updates

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -106,6 +106,7 @@
             "build-commands": [
                 "install -Dm755 discord.sh /app/bin/discord",
                 "install -Dm755 set-gtk-dark-theme.py /app/bin",
+                "install -Dm755 disable-breaking-updates.py /app/bin",
                 "mv Discord /app/discord",
                 "chmod +x /app/discord/Discord",
                 "install -d /app/share/applications",
@@ -136,6 +137,10 @@
                 {
                     "type": "file",
                     "path": "set-gtk-dark-theme.py"
+                },
+                {
+                    "type": "file",
+                    "path": "disable-breaking-updates.py"
                 }
             ],
             "modules": [

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Disable breaking updates which will prompt users to download a deb or tar file
+and lock them out of Discord making the program unusable.
+
+This will dramatically improve the experience :
+
+ 1) The maintainer doesn't need to be worried at all times of an update which will break Discord.
+ 2) People will not be locked out of the program while the maintainer runs to update it.
+
+"""
+
+import json
+import os
+from pathlib import Path
+
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME")
+if Path(f"{XDG_CONFIG_HOME}/discord/settings.json").is_file():
+    with open(f"{XDG_CONFIG_HOME}/discord/settings.json", "r+") as settings_file:
+        settings = json.load(settings_file)
+        if settings.get("SKIP_HOST_UPDATE"):
+            print("Disabling updates already done")
+        else:
+            skip_host_update = {"SKIP_HOST_UPDATE":True}
+            settings.update(skip_host_update)
+            settings_file.seek(0)
+            json.dump(settings, settings_file, indent = 2)
+            print("Disabled updates")
+            
+else:
+    print("settings.json doesn't yet exist, can't disable it yet")

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -20,7 +20,7 @@ XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
 
 settings_path = Path(f"{XDG_CONFIG_HOME}/discord/settings.json")
 settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
-if settings_path.is_file():
+try:
     with settings_path.open() as settings_file:
         settings = json.load(settings_file)
         if settings.get("SKIP_HOST_UPDATE"):
@@ -34,5 +34,5 @@ if settings_path.is_file():
                 settings_path_temp.rename(settings_path)
                 print("Disabled updates")
             
-else:
+except IOError:
     print("settings.json doesn't yet exist, can't disable it yet")

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -23,16 +23,18 @@ settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
 try:
     with settings_path.open() as settings_file:
         settings = json.load(settings_file)
+
         if settings.get("SKIP_HOST_UPDATE"):
             print("Disabling updates already done")
         else:
+            skip_host_update = {"SKIP_HOST_UPDATE":True}
+            settings.update(skip_host_update)
+
             with settings_path_temp.open('w') as settings_file_temp:
-                skip_host_update = {"SKIP_HOST_UPDATE":True}
-                settings.update(skip_host_update)
-                settings_file.seek(0)
                 json.dump(settings, settings_file_temp, indent = 2)
-                settings_path_temp.rename(settings_path)
-                print("Disabled updates")
+
+            settings_path_temp.rename(settings_path)
+            print("Disabled updates")
             
 except IOError:
     print("settings.json doesn't yet exist, can't disable it yet")

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -14,18 +14,25 @@ import json
 import os
 from pathlib import Path
 
-XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME")
-if Path(f"{XDG_CONFIG_HOME}/discord/settings.json").is_file():
-    with open(f"{XDG_CONFIG_HOME}/discord/settings.json", "r+") as settings_file:
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+    os.path.expanduser("~"), ".config"
+)
+
+settings_path = Path(f"{XDG_CONFIG_HOME}/discord/settings.json")
+settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
+if settings_path.is_file():
+    with settings_path.open() as settings_file:
         settings = json.load(settings_file)
         if settings.get("SKIP_HOST_UPDATE"):
             print("Disabling updates already done")
         else:
-            skip_host_update = {"SKIP_HOST_UPDATE":True}
-            settings.update(skip_host_update)
-            settings_file.seek(0)
-            json.dump(settings, settings_file, indent = 2)
-            print("Disabled updates")
+            with settings_path_temp.open('w') as settings_file_temp:
+                skip_host_update = {"SKIP_HOST_UPDATE":True}
+                settings.update(skip_host_update)
+                settings_file.seek(0)
+                json.dump(settings, settings_file_temp, indent = 2)
+                settings_path_temp.rename(settings_path)
+                print("Disabled updates")
             
 else:
     print("settings.json doesn't yet exist, can't disable it yet")

--- a/discord.sh
+++ b/discord.sh
@@ -5,7 +5,7 @@ socat $SOCAT_ARGS \
     UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
     &
 socat_pid=$!
-disable-breaking-updates.py &
+disable-breaking-updates.py
 set-gtk-dark-theme.py &
 env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord "$@"
 kill -SIGTERM $socat_pid

--- a/discord.sh
+++ b/discord.sh
@@ -5,6 +5,7 @@ socat $SOCAT_ARGS \
     UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
     &
 socat_pid=$!
+disable-breaking-updates.py &
 set-gtk-dark-theme.py &
 env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord "$@"
 kill -SIGTERM $socat_pid


### PR DESCRIPTION
Discord has two types of updates, those that change the discord binary and those that update
scripts, css and mutable things.

Through Discord's settings.json, it is possible to disable updates which change the binary.

This means that people will no longer be locked out of Discord and prompted to get a tarball or deb file.
They will still get regular non-binary updates through Discord. Flatpak will take care of changing the binary as it always has.

Fix #154 