### PR TITLE
Remove useless permissions

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -20,12 +20,10 @@
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-pictures:ro",
         "--filesystem=xdg-download",
-        "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=com.canonical.AppMenu.Registrar",
         "--talk-name=com.canonical.indicator.application",
-        "--talk-name=com.canonical.Unity.LauncherEntry",
-        "--env=XDG_CURRENT_DESKTOP=ubuntu:GNOME"
+        "--talk-name=com.canonical.Unity.LauncherEntry"
     ],
     "modules": [
         {


### PR DESCRIPTION
fcitx was introduced in https://github.com/flathub/com.discordapp.Discord/pull/63 due to a fcitx change which should no longer be needed.
The env variable for ubuntu:GNOME was done for experiments regarding application badges. I never managed to make it work and I don't think this will help with that so it's removed

I'd *like* testing otherwise I'll pass it in 24hours. I don't really think it *needs* testing.