### PR TITLE
Fixed screenshot and icon URLs

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -7,7 +7,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://discord.com</url>
-  <icon type="remote" height="256" width="256">https://discord.com/assets/2c21aeda16de354ba5334551a883b481.png</icon>
+  <icon type="remote" height="256" width="256">https://support.discord.com/hc/user_images/bbW4u80g7yIVxsphv9diNw.png</icon>
   <description>
     <p>Discord is a free all in one messaging, voice, and video client thats available on your computer and phone.</p>
     <p>Whether you’re part of a school club, gaming group, worldwide art community, or just a handful of friends that want to spend time together, Discord makes it easy to talk every day and hang out more often.</p>
@@ -25,24 +25,20 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://discord.com/assets/882599fca31a23ad38bd47db302b2a00.png</image>
-      <caption>Talk on an invite only server</caption>
+      <image type="source">https://discord.com/assets/46b2132c01604c9493d558de444929f4.svg</image>
+      <caption>Chat on topic based channels</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://discord.com/assets/43fb8531fc13f02eb5f3c3e16d7fd1a7.png</image>
-      <caption>Voice and Video</caption>
+      <image type="source">https://discord.com/assets/575a0322f3b36ca2fecb23ad2c6dd5ad.svg</image>
+      <caption>Talk in groups</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://discord.com/assets/8626705c42db1fee19fc95fff7480bf8.png</image>
-      <caption>Dark Mode Window</caption>
+      <image type="source">https://discord.com/assets/921b1ae33edca174b6ebe787bb8b6c3b.svg</image>
+      <caption>Manage communites</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://discord.com/assets/783ec8164addfd314cab6b0fa4ef6fc5.png</image>
-      <caption>Light Mode Window</caption>
-    </screenshot>
-    <screenshot>
-      <image type="source">https://discord.com/assets/489dc2b446be5c305571ad96b845c776.png</image>
-      <caption>Available on Linux, macOS, Windows, iOS, Android, and your web browser</caption>
+      <image type="source">https://discord.com/assets/98ea5b9e92e304c7d352ac462996adc5.svg</image>
+      <caption>Video talks and screen sharing</caption>
     </screenshot>
   </screenshots>
   <kudos>

--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -25,20 +25,24 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://discord.com/assets/46b2132c01604c9493d558de444929f4.svg</image>
-      <caption>Chat on topic based channels</caption>
+      <image type="source">https://web.archive.org/web/20210930201229if_/https://discord.com/assets/882599fca31a23ad38bd47db302b2a00.png</image>
+      <caption>Talk on an invite only server</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://discord.com/assets/575a0322f3b36ca2fecb23ad2c6dd5ad.svg</image>
-      <caption>Talk in groups</caption>
+      <image type="source">https://web.archive.org/web/20210930201229if_/https://discord.com/assets/43fb8531fc13f02eb5f3c3e16d7fd1a7.png</image>
+      <caption>Voice and Video</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://discord.com/assets/921b1ae33edca174b6ebe787bb8b6c3b.svg</image>
-      <caption>Manage communites</caption>
+      <image type="source">https://web.archive.org/web/20210930201229if_/https://discord.com/assets/8626705c42db1fee19fc95fff7480bf8.png</image>
+      <caption>Dark Mode Window</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://discord.com/assets/98ea5b9e92e304c7d352ac462996adc5.svg</image>
-      <caption>Video talks and screen sharing</caption>
+      <image type="source">https://web.archive.org/web/20210930201229if_/https://discord.com/assets/783ec8164addfd314cab6b0fa4ef6fc5.png</image>
+      <caption>Light Mode Window</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://web.archive.org/web/20210930201229if_/https://discord.com/assets/489dc2b446be5c305571ad96b845c776.png</image>
+      <caption>Available on Linux, macOS, Windows, iOS, Android, and your web browser</caption>
     </screenshot>
   </screenshots>
   <kudos>


### PR DESCRIPTION
I took the new ones from https://discord.com/ main page and https://support.discord.com/hc/en-us/community/posts/1500001193282-App-icon-on-Desktop-Linux-and-Windows-