### PR TITLE
Fix Spotify rich prescence

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -20,6 +20,7 @@
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-pictures:ro",
         "--filesystem=xdg-download",
+        "--filesystem=xdg-data/Spotify:ro",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=com.canonical.AppMenu.Registrar",
         "--talk-name=com.canonical.indicator.application",


### PR DESCRIPTION
Without access to Spotify, the following features will not work correctly:
https://support.spotify.com/us/article/discord-and-spotify/
https://support.discord.com/hc/en-us/articles/360000167212-Discord-Spotify-Connection