### PR TITLE
Use HW acceleration arguments for electron

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -7,5 +7,5 @@ socat $SOCAT_ARGS \
 socat_pid=$!
 disable-breaking-updates.py
 set-gtk-dark-theme.py &
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord "$@"
+env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord --enable-gpu-rasterization --enable-zero-copy "$@"
 kill -SIGTERM $socat_pid


### PR DESCRIPTION
This doesn't disable the gpu blacklist so this won't actually change things for everyone.

I'm unsure why we need this when the Discord settings have an hw accel option but it appears to do nothing.

This however does seem to improve performance for people so we should do it.

I want people other than myself to test this.