### PR TITLE
Use more rendering features of electron to further improve performance

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -7,5 +7,5 @@ socat $SOCAT_ARGS \
 socat_pid=$!
 disable-breaking-updates.py
 set-gtk-dark-theme.py &
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord --enable-gpu-rasterization --enable-zero-copy "$@"
+env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord --enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,CanvasOopRasterization "$@"
 kill -SIGTERM $socat_pid


### PR DESCRIPTION
We can use the GPU for compositing, we can use better buffers for it, we can seperate the gpu process to avoid problems in the main thread slowing down rendering.

I would use Ozone but I'll wait for an Electron update so we can match when Ozone became default for X11.