### PR TITLE
Fix Nvidia rendering on Xwayland

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -5,7 +5,15 @@ socat $SOCAT_ARGS \
     UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
     &
 socat_pid=$!
+
+FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,CanvasOopRasterization'
+
+if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -f /dev/nvidia0 ]
+then
+    FLAGS="$FLAGS --disable-gpu-sandbox"
+fi
+
 disable-breaking-updates.py
 set-gtk-dark-theme.py &
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord --enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,CanvasOopRasterization "$@"
+env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord $FLAGS "$@"
 kill -SIGTERM $socat_pid

--- a/discord.sh
+++ b/discord.sh
@@ -8,7 +8,7 @@ socat_pid=$!
 
 FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,CanvasOopRasterization'
 
-if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -f /dev/nvidia0 ]
+if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then
     FLAGS="$FLAGS --disable-gpu-sandbox"
 fi


### PR DESCRIPTION
This should fix the black screen being rendered on Nvidia
when using Xwayland which is caused by an electron bug

I wish I could just update Electron to fix it instead of this
but Discord is proprietary so it's outside of my power

This will result in a security regression for hybrid GPUs in its
state but handling the Nvidia bug seems important