### PR TITLE
Fix captcha during login

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -6,7 +6,7 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,CanvasOopRasterization'
+FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer'
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then


### PR DESCRIPTION
When clicking "I'm not a robot" during the login, the app hangs for about a minute and then the captcha turns gray. This can be narrowed down to the use of the `CanvasOopRasterization` flag in `discord.sh`.

Closes #210 