### PR TITLE
Set wayland flags when appropiate

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -6,7 +6,20 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer'
+FEATURES="UseSkiaRenderer"
+
+if [[ $XDG_SESSION_TYPE == "wayland" ]]
+then
+    FEATURES="$FEATURES,WebRTCPipeWireCapturer,WaylandWindowDecorations"
+fi
+
+FLAGS="--ozone-platform-hint=auto \
+--enable-gpu-rasterization \
+--enable-zero-copy \
+--enable-gpu-compositing \
+--enable-native-gpu-memory-buffers \
+--enable-oop-rasterization \
+--enable-features=$FEATURES"
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then

--- a/discord.sh
+++ b/discord.sh
@@ -10,7 +10,7 @@ FEATURES="UseSkiaRenderer"
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]]
 then
-    FEATURES="$FEATURES,WebRTCPipeWireCapturer,WaylandWindowDecorations"
+    FEATURES="$FEATURES,WaylandWindowDecorations"
 fi
 
 FLAGS="--ozone-platform-hint=auto \


### PR DESCRIPTION
~- `WebRTCPipeWireCapturer`: use Pipewire to stream~
- `WaylandWindowDecorations`: show CSD ([available since electron17](https://github.com/electron/electron/pull/29618))
- `--ozone-platform-hint=auto`: enable Wayland when possible ([available since electron 18](https://github.com/electron/electron/pull/34937))

Since some flags depend on the Electron version and I don't know which version Discord bundles, this might require waiting.