### PR TITLE
Disable forced updates before the first startup

### DIFF
--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -23,18 +23,18 @@ settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
 try:
     with settings_path.open() as settings_file:
         settings = json.load(settings_file)
-
-        if settings.get("SKIP_HOST_UPDATE"):
-            print("Disabling updates already done")
-        else:
-            skip_host_update = {"SKIP_HOST_UPDATE":True}
-            settings.update(skip_host_update)
-
-            with settings_path_temp.open('w') as settings_file_temp:
-                json.dump(settings, settings_file_temp, indent = 2)
-
-            settings_path_temp.rename(settings_path)
-            print("Disabled updates")
-            
 except IOError:
-    print("settings.json doesn't yet exist, can't disable it yet")
+    settings_path.parent.mkdir(parents = True, exist_ok = True)
+    settings = {}
+
+if settings.get("SKIP_HOST_UPDATE"):
+    print("Disabling updates already done")
+else:
+    skip_host_update = {"SKIP_HOST_UPDATE":True}
+    settings.update(skip_host_update)
+
+    with settings_path_temp.open('w') as settings_file_temp:
+        json.dump(settings, settings_file_temp, indent = 2)
+
+    settings_path_temp.rename(settings_path)
+    print("Disabled updates")

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -24,7 +24,7 @@ try:
     with settings_path.open() as settings_file:
         settings = json.load(settings_file)
 except IOError:
-    settings_path.parent.mkdir(parents = True, exist_ok = True)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings = {}
 
 if settings.get("SKIP_HOST_UPDATE"):

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -34,7 +34,7 @@ else:
     settings.update(skip_host_update)
 
     with settings_path_temp.open('w') as settings_file_temp:
-        json.dump(settings, settings_file_temp, indent = 2)
+        json.dump(settings, settings_file_temp, indent=2)
 
     settings_path_temp.rename(settings_path)
     print("Disabled updates")


### PR DESCRIPTION
Currently the `disable-breaking-updates.py` script disables updates only if the `settings.json` file already exists in the Discord config directory.  This renders the flatpak essentially useless for new users in the short intervals between a new update being released by Discord and the new version being available on Flathub, see #263, #262 and #252 for some recent examples.

This change makes the script write a dummy `settings.json` file with updates disabled if it doesn't already exist, hopefully eliminating this kind of issues.