### PR TITLE
Respect $WAYLAND_DISPLAY env var when checking if running in wayland

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -8,7 +8,9 @@ socat_pid=$!
 
 FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,WaylandWindowDecorations'
 
-if [[ -e "$XDG_RUNTIME_DIR/wayland-0" ]]
+WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+
+if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" ]]
 then
     FLAGS="$FLAGS --ozone-platform-hint=auto"
 fi


### PR DESCRIPTION
Some compositors name the wayland socket something other than `wayland-0`. Namely, sway seems to name it `wayland-1`. This is reflected on the `$WAYLAND_DISPLAY` environment variable, so we can use that to check for the wayland socket.