### PR TITLE
Give permission to inhibit screensaver

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -17,6 +17,7 @@
         "--share=network",
         "--device=all",
         "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.freedesktop.ScreenSaver",
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-pictures:ro",
         "--filesystem=xdg-download",


### PR DESCRIPTION
Access to org.freedesktop.ScreenSaver is needed in order to allow Discord to inhibit screensaver, otherwise screen may go blank in the middle of a video call.