### PR TITLE
Revert "Pass --use-gl=desktop for Nvidia+Wayland"

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -17,7 +17,7 @@ fi
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then
-    FLAGS="$FLAGS --use-gl=desktop"
+    FLAGS="$FLAGS --disable-gpu-sandbox"
 fi
 
 disable-breaking-updates.py


### PR DESCRIPTION
Reverts flathub/com.discordapp.Discord#312

This broke Discord on Nvidia+Wayland for me