### PR TITLE
correctly handle present-but-empty settings.json in breaking updates script

### DIFF
--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -23,7 +23,7 @@ settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
 try:
     with settings_path.open() as settings_file:
         settings = json.load(settings_file)
-except IOError:
+except (IOError, json.decoder.JSONDecodeError):
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings = {}
 


### PR DESCRIPTION
If Discord's `settings.json` was present but empty, `disable-breaking-updates.py` would throw a JSONDecode error and fail to add the skip update field.

This PR adds the JSONDecode error to the `except` handler so the script continues and the file gets updated with the correct content.
