### PR TITLE
Update to 23.08 runtime

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.discordapp.Discord",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "22.08",
+    "base-version": "23.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "discord",
     "separate-locales": false,

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -16,7 +16,6 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.ScreenSaver",
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-pictures:ro",


### PR DESCRIPTION
org.freedesktop.Notifications permission removed because of: [gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25](https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25)