### PR TITLE
Use Vulkan for NVIDIA GPUs on Wayland

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -17,7 +17,7 @@ fi
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then
-    FLAGS="$FLAGS --disable-gpu-sandbox"
+    FLAGS="$FLAGS --use-vulkan"
 fi
 
 disable-breaking-updates.py


### PR DESCRIPTION
 * --disable-gpu-sandbox prevents Discord from starting on Wayland on an RTX 4080, enabling Vulkan allows it to launch. Notably the animations are very smooth.

Closes #331