### PR TITLE
Metainfo: Remove "none" OARS content attributes

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -72,33 +72,11 @@
     <release version="0.0.13" date="2020-12-04"/>
   </releases>
   <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>
     <content_attribute id="social-info">intense</content_attribute>
     <content_attribute id="social-audio">intense</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
     <content_attribute id="social-contacts">intense</content_attribute>
     <content_attribute id="money-purchasing">intense</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <update_contact>tingping_at_fedoraproject.org</update_contact>
 </application>


### PR DESCRIPTION
Empty OARS content attributes are implicitly `none`; excluding them makes it easier to see at a glance what attributes are of interest.