### PR TITLE
Metainfo: drop the "unofficial" line

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,3 @@ To opt-out do the same with `--nosocket=wayland`.
 ## Legal
 
 The Discord app itself is **proprietary** (closed source).
-
-This wrapper is not verified by, affiliated with, or supported by Discord Inc.

--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -9,7 +9,6 @@
   <url type="homepage">https://discord.com</url>
   <icon type="remote" height="256" width="256">https://support.discord.com/hc/user_images/bbW4u80g7yIVxsphv9diNw.png</icon>
   <description>
-    <p>This wrapper is not verified by, affiliated with, or supported by Discord Inc.</p>
     <p>Discord is a free all in one messaging, voice, and video client thats available on your computer and phone.</p>
     <p>Whether you’re part of a school club, gaming group, worldwide art community, or just a handful of friends that want to spend time together, Discord makes it easy to talk every day and hang out more often.</p>
     <ul>


### PR DESCRIPTION
They've verified it and have commit access here, so I think we can safely remove this 😄