### PR TITLE
changed executable name from "discord" to "com.discordapp.Discord" to fix #348

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -5,7 +5,7 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
-    "command": "discord",
+    "command": "com.discordapp.Discord",
     "separate-locales": false,
     "tags": [
         "proprietary"
@@ -53,12 +53,12 @@
             "name": "discord",
             "buildsystem": "simple",
             "build-commands": [
-                "install -Dm755 discord.sh /app/bin/discord",
+                "install -Dm755 discord.sh /app/bin/com.discordapp.Discord",
                 "install -Dm755 disable-breaking-updates.py /app/bin",
                 "mv Discord /app/discord",
                 "chmod +x /app/discord/Discord",
                 "install -d /app/share/applications",
-                "sed -e 's/Icon=discord/Icon=com.discordapp.Discord/' -e 's|Exec=/usr/share/discord/Discord|Exec=discord|' /app/discord/discord.desktop > /app/share/applications/${FLATPAK_ID}.desktop",
+                "sed -e 's/Icon=discord/Icon=com.discordapp.Discord/' -e 's|Exec=/usr/share/discord/Discord|Exec=com.discordapp.Discord|' /app/discord/discord.desktop > /app/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 /app/discord/discord.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png",
                 "install -Dm644 com.discordapp.Discord.appdata.xml /app/share/appdata/com.discordapp.Discord.appdata.xml"
             ],


### PR DESCRIPTION
because of xdg-shell standard, for the system to know what icon display, it need to be the same binary name, kde is [strict](https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon) about that, so the icon bugs is more [common](https://bugs.kde.org/show_bug.cgi?id=459536) in there, this fixes #348
tested on KDE Plasma
