### PR TITLE
Actually enable Vulkan, and give it to everyone

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -6,18 +6,13 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,WaylandWindowDecorations'
+FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,Vulkan,WaylandWindowDecorations --use-vulkan'
 
 WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 
 if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" ]]
 then
     FLAGS="$FLAGS --ozone-platform-hint=auto"
-fi
-
-if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
-then
-    FLAGS="$FLAGS --use-vulkan"
 fi
 
 disable-breaking-updates.py


### PR DESCRIPTION
In particular, for Vulkan, `--enable-features=Vulkan` will cause Vulkan to be used for compositing and rasterization, whereas `--use-vulkan` by itself will only initialize Vulkan so that it can be used for other purposes, such as WebGPU.

https://github.com/electron/electron/issues/40929