### PR TITLE
Fix wayland detection in some systems

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -6,7 +6,9 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET:-'wayland-0'}" || -e "${WAYLAND_DISPLAY}" ]]
+WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+
+if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
     FLAGS="--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto"
 fi

--- a/discord.sh
+++ b/discord.sh
@@ -6,7 +6,7 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:-'wayland-0'}" || -e "${WAYLAND_SOCKET}" ]]
+if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET:-'wayland-0'}" || -e "${WAYLAND_DISPLAY}" ]]
 then
     FLAGS="--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto"
 fi

--- a/discord.sh
+++ b/discord.sh
@@ -6,9 +6,7 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
-
-if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" ]]
+if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:-'wayland-0'}" || -e "${WAYLAND_SOCKET}" ]]
 then
     FLAGS="--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto"
 fi


### PR DESCRIPTION
Flatpak seems to be setting ${WAYLAND_DISPLAY} to an absolute path in some systems. This was causing the wayland check to fail because we were looking for the wrong path. This change should support all cases now.

Same fix applied to https://github.com/flathub/com.slack.Slack/pull/271