### PR TITLE
appdata: Make appstream component ID match $FLATPAK_ID

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>com.discordapp.Discord.desktop</id>
+  <id>com.discordapp.Discord</id>
   <name>Discord</name>
   <developer_name>Discord Inc.</developer_name>
   <summary>Messaging, voice and video client</summary>
@@ -52,6 +52,12 @@
     <category>InstantMessaging</category>
     <category>Network</category>
   </categories>
+  <replaces>
+    <id>com.discordapp.Discord.desktop</id>
+  </replaces>
+  <provides>
+    <id>com.discordapp.Discord.desktop</id>
+  </provides>
   <releases>
     <release version="0.0.47" date="2024-03-25"/>
     <release version="0.0.46" date="2024-03-18"/>


### PR DESCRIPTION
Appstreamcli creates icons following the component id instead of $FLATPAK_ID but Flatpak ignores it because it doesn't match $FLATPAK_ID when copying the icons to appstream ref. So the ref is missing 64px and 128px icons entirely for the app.

This makes GNOME software show a blank icon in list view because it looks up icons from flatpak's appstream cache.

Make both match and link older IDs with replaces and provides.

See https://github.com/flathub/flathub/issues/4222#issuecomment-2018726736