### PR TITLE
Allow UPower access through the system message bus

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -25,6 +25,7 @@
         "--talk-name=com.canonical.AppMenu.Registrar",
         "--talk-name=com.canonical.indicator.application",
         "--talk-name=com.canonical.Unity",
+        "--system-talk-name=org.freedesktop.UPower",
         "--own-name=org.kde.*",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons",
         "--env=XDG_CURRENT_SESSION=KDE",


### PR DESCRIPTION
This silences the following errors (they're probably harmless, though), given by Chromium at startup:

```
$ flatpak run com.discordapp.Discord
Disabling updates already done
[5:0518/150641.657173:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[5:0518/150642.368402:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[5:0518/150642.368473:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
```

I _think_ Chromium needs this to control screen inhibition.