### PR TITLE
Disable Flathub's update checker and PR auto-merging

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -72,12 +72,7 @@
                     "type": "archive",
                     "url": "https://dl.discordapp.net/apps/linux/0.0.68/discord-0.0.68.tar.gz",
                     "sha256": "483cd8e228fac83fec0da3fa930f46f5edd2b339a2517aca11dccbaed120f07a",
-                    "strip-components": 0,
-                    "x-checker-data": {
-                        "type": "rotating-url",
-                        "url": "https://discord.com/api/download?platform=linux&format=tar.gz",
-                        "pattern": "https://dl.discordapp.net/apps/linux/([0-9.]+)/discord-([0-9.]+).tar.gz"
-                    }
+                    "strip-components": 0
                 },
                 {
                     "type": "file",

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-  "only-arches": ["x86_64"],
-  "automerge-flathubbot-prs": true
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
At least until upstream addresses the following issue:

https://github.com/flathub-infra/flatpak-external-data-checker/issues/438

This is to prevent the bot from opening (and merging) [multiple pull requests](https://github.com/flathub/com.discordapp.Discord/pulls?q=is%3Apr+author%3Aflathubbot+is%3Aclosed) that point to the same version.

Closes #437