### PR TITLE
Allow reading launch flags from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ flatpak override --user --socket=wayland com.discordapp.Discord
 
 To opt-out do the same with `--nosocket=wayland`.
 
+### Persistent launch options
+
+To make Discord's launch options persistent, add them to `~/.var/app/com.discordapp.Discord/config/discord-flags.conf` (one option per line):
+
+```conf
+# This line will be ignored
+--enable-features=WaylandWindowDecorations
+
+# https://chromium.googlesource.com/chromium/src/+/master/docs/linux/password_storage.md
+--password-store=basic
+```
+
 ## Legal
 
 The Discord app itself is **proprietary** (closed source).

--- a/discord.sh
+++ b/discord.sh
@@ -6,13 +6,18 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
+if [ -f "${XDG_CONFIG_HOME}/discord-flags.conf" ]
+then
+    mapfile -t FLAGS <<< "$(grep -Ev '^\s*$|^#' "${XDG_CONFIG_HOME}/discord-flags.conf")"
+fi
+
 WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 
 if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
-    FLAGS="--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto"
+    FLAGS+=('--enable-features=WaylandWindowDecorations' '--ozone-platform-hint=auto')
 fi
 
 disable-breaking-updates.py
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord --enable-speech-dispatcher $FLAGS "$@"
+env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord --enable-speech-dispatcher "${FLAGS[@]}" "$@"
 kill -SIGTERM $socat_pid


### PR DESCRIPTION
This makes it easier for users to set persistent launch options.

Idea and implementation shamelessly stolen from the Flatpak package for Spotify.

Closes #402