### PR TITLE
Always remove socket file before invoking socat

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 FLATPAK_ID=${FLATPAK_ID:-"com.discordapp.Discord"}
-socat $SOCAT_ARGS \
-    UNIX-LISTEN:$XDG_RUNTIME_DIR/app/${FLATPAK_ID}/discord-ipc-0,forever,fork \
-    UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
+OUR_SOCKET="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}/discord-ipc-0"
+DISCORD_SOCKET="${XDG_RUNTIME_DIR}/discord-ipc-0"
+
+rm -f "${OUR_SOCKET}"
+
+socat ${SOCAT_ARGS} \
+    "UNIX-LISTEN:${OUR_SOCKET},forever,fork" \
+    "UNIX-CONNECT:${DISCORD_SOCKET}/discord-ipc-0" \
     &
 socat_pid=$!
 


### PR DESCRIPTION
Sometimes, for reasons unknown, the socket file created when we invoke `socat`, fails to get removed when Discord exits.

Then, the next time we launch Discord, `socat` is invoked again, but it fails with this error:

```
2024/10/03 16:21:27 socat[4] E "/run/user/1000/app/com.discordapp.Discord/discord-ipc-0" exists
```

And that causes Discord's Rich Presence feature not to work properly.

This change avoids that situation by always removing the socket file before invoking socat.

This **likely** fixes #241, assuming the user has [set up Discord's RPC](https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-\(discord-rpc\)#unsandboxed-applications) properly.