### PR TITLE
metainfo: Expand and modernize

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>com.discordapp.Discord.desktop</id>
+  <id>com.discordapp.Discord</id>
   <name>Discord</name>
-  <developer_name>Discord Inc.</developer_name>
+  <developer id="com.discord">
+    <name>Discord Inc.</name>
+  </developer>
   <summary>Messaging, voice and video client</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
@@ -44,14 +46,30 @@
       <caption>Available on Linux, macOS, Windows, iOS, Android, and your web browser</caption>
     </screenshot>
   </screenshots>
-  <kudos>
-    <kudo>HiDpiIcon</kudo>
-    <kudo>Notifications</kudo>
-  </kudos>
+  <branding>
+    <color type="primary" scheme_preference="light">#a0aaf3</color>
+    <color type="primary" scheme_preference="dark">#3831a8</color>
+  </branding>
   <categories>
     <category>InstantMessaging</category>
     <category>Network</category>
   </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+    <content_attribute id="money-purchasing">intense</content_attribute>
+  </content_rating>
+  <requires>
+    <display_length compare="ge">940</display_length>
+    <internet>always</internet>
+  </requires>
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+  </supports>
+  <update_contact>tingping_at_fedoraproject.org</update_contact>
   <releases>
     <release version="0.0.70" date="2024-10-01">
       <description/>
@@ -144,12 +162,4 @@
     <release version="0.0.14" date="2021-03-23"/>
     <release version="0.0.13" date="2020-12-04"/>
   </releases>
-  <content_rating type="oars-1.1">
-    <content_attribute id="social-chat">intense</content_attribute>
-    <content_attribute id="social-info">intense</content_attribute>
-    <content_attribute id="social-audio">intense</content_attribute>
-    <content_attribute id="social-contacts">intense</content_attribute>
-    <content_attribute id="money-purchasing">intense</content_attribute>
-  </content_rating>
-  <update_contact>tingping_at_fedoraproject.org</update_contact>
 </component>

--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -69,7 +69,7 @@
     <control>keyboard</control>
     <control>pointing</control>
   </supports>
-  <update_contact>tingping_at_fedoraproject.org</update_contact>
+  <update_contact>support@discordapp.com</update_contact>
   <releases>
     <release version="0.0.70" date="2024-10-01">
       <description/>


### PR DESCRIPTION
- Move everything non-release-related above `<releases>` since the changelogs accumulate over time
- Remove `.desktop` from app ID as it's ignored anyways
- Remove obsolete `<kudos>` tag
- Change from `<developer_name>` to `<developer>`
- Add brand colors
- Add HW support information