### PR TITLE
Remove unused `shared-modules` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules


### PR DESCRIPTION
This submodule was used in the past to build libappindicator, but we stopped doing that in 2021 (ref.: 3c1459a6e95e06b40f44bbe24335461cc2058635).