### PR TITLE
Drop `--own-name=org.kde.*` permission

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -26,7 +26,6 @@
         "--talk-name=com.canonical.indicator.application",
         "--talk-name=com.canonical.Unity",
         "--system-talk-name=org.freedesktop.UPower",
-        "--own-name=org.kde.*",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons",
         "--env=XDG_CURRENT_SESSION=KDE",
         "--env=ELECTRON_TRASH=gio"


### PR DESCRIPTION
This permission is only required for Electron versions older than 23.3.0, and current Discord (0.0.70) includes Electron 32.0.0.

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

Closes #283

@bbhtt You might want to remove [this exception](https://github.com/flathub-infra/flatpak-builder-lint/blob/6d8a1417a51c10e24b374b428c8440069e95968d/flatpak_builder_lint/staticfiles/exceptions.json#L1978) now.