### PR TITLE
Unset `XDG_CURRENT_SESSION` environment variable

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -27,7 +27,6 @@
         "--talk-name=com.canonical.Unity",
         "--system-talk-name=org.freedesktop.UPower",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons",
-        "--env=XDG_CURRENT_SESSION=KDE",
         "--env=ELECTRON_TRASH=gio"
     ],
     "modules": [


### PR DESCRIPTION
This was introduced by #368 as a workaround to trick Electron into making use of the Unity API.

However, as of Electron 32.0.0 (included with Discord 0.0.70), this workaround [is not needed anymore](https://github.com/electron/electron/commit/07a68c2bf8b53ea1c639b5c12fa725e5ae81fab0).