### PR TITLE
Remove unused `pciutils` module

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -67,31 +67,6 @@
             ],
             "modules": [
                 {
-                    "name": "pciutils",
-                    "disabled": true,
-                    "no-autogen": true,
-                    "make-args": [
-                        "SHARED=yes",
-                        "PREFIX=/app"
-                    ],
-                    "make-install-args": [
-                        "SHARED=yes",
-                        "PREFIX=/app"
-                    ],
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "https://github.com/pciutils/pciutils/archive/v3.13.0.tar.gz",
-                            "sha256": "861fc26151a4596f5c3cb6f97d6c75c675051fa014959e26fb871c8c932ebc67",
-                            "x-checker-data": {
-                                "type": "anitya",
-                                "project-id": 2605,
-                                "url-template": "https://github.com/pciutils/pciutils/archive/v$version.tar.gz"
-                            }
-                        }
-                    ]
-                },
-                {
                     "name": "socat",
                     "sources": [
                         {


### PR DESCRIPTION
This dependency [has been disabled](https://github.com/flathub/com.discordapp.Discord/blob/76b10f9c1032cf2912ce54c3b36daac61e2ab1c7/com.discordapp.Discord.json#L71) since it was first introduced by commit b099c052cf0d4769db73340cc71c4230c00ba68b, but no one noticed it until now, I guess.