### PR TITLE
metainfo: Add URLs

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -9,6 +9,10 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://discord.com</url>
+  <url type="help">https://support.discord.com</url>
+  <url type="bugtracker">https://support.discord.com/hc/categories/115000168371</url>
+  <url type="contact">https://discord.com/company-information</url>
+  <url type="donation">https://discord.com/nitro</url>
   <launchable type="desktop-id">com.discordapp.Discord.desktop</launchable>
   <description>
     <p>Discord is a free all in one messaging, voice, and video client thats available on your computer and phone.</p>

--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -12,7 +12,6 @@
   <url type="help">https://support.discord.com</url>
   <url type="bugtracker">https://support.discord.com/hc/categories/115000168371</url>
   <url type="contact">https://discord.com/company-information</url>
-  <url type="donation">https://discord.com/nitro</url>
   <launchable type="desktop-id">com.discordapp.Discord.desktop</launchable>
   <description>
     <p>Discord is a free all in one messaging, voice, and video client thats available on your computer and phone.</p>


### PR DESCRIPTION
Add different URLs that may be of use to people downloading and using Discord. Linking to the Nitro page is definitely stretching the intended use case of the `donation` URL type by a mile, but I thought the idea was too good to not suggest.