### PR TITLE
Build socat with most features disabled

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -31,6 +31,37 @@
     ],
     "modules": [
         {
+            "name": "socat",
+            "config-opts": [
+                "--disable-largefile", "--disable-stats", "--disable-stdio", "--disable-fdnum", "--disable-file",
+                "--disable-creat", "--disable-gopen", "--disable-pipe", "--disable-socketpair", "--disable-termios",
+                "--disable-abstract-unixsocket", "--disable-ip6", "--disable-rawip", "--disable-genericsocket",
+                "--disable-interface", "--disable-tcp", "--disable-udp", "--disable-udplite", "--disable-sctp",
+                "--disable-dccp", "--disable-vsock", "--disable-namespaces", "--disable-posixmq", "--disable-socks4",
+                "--disable-socks4a", "--disable-socks5", "--disable-proxy", "--disable-exec", "--disable-system",
+                "--disable-shell", "--disable-pty", "--disable-fs", "--disable-readline", "--disable-openssl",
+                "--disable-tun", "--disable-sycls", "--disable-filan", "--disable-libwrap", "--disable-resolve"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.dest-unreach.org/socat/download/socat-1.8.0.1.tar.gz",
+                    "sha256": "dc350411e03da657269e529c4d49fe23ba7b4610b0b225c020df4cf9b46e6982",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 4848,
+                        "url-template": "http://www.dest-unreach.org/socat/download/socat-$version.tar.gz"
+                    }
+                }
+            ],
+            "cleanup": [
+                "/bin/*.sh",
+                "/bin/filan",
+                "/bin/procan",
+                "/share"
+            ]
+        },
+        {
             "name": "discord",
             "buildsystem": "simple",
             "build-commands": [
@@ -63,23 +94,6 @@
                 {
                     "type": "file",
                     "path": "disable-breaking-updates.py"
-                }
-            ],
-            "modules": [
-                {
-                    "name": "socat",
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "http://www.dest-unreach.org/socat/download/socat-1.8.0.1.tar.gz",
-                            "sha256": "dc350411e03da657269e529c4d49fe23ba7b4610b0b225c020df4cf9b46e6982",
-                            "x-checker-data": {
-                                "type": "anitya",
-                                "project-id": 4848,
-                                "url-template": "http://www.dest-unreach.org/socat/download/socat-$version.tar.gz"
-                            }
-                        }
-                    ]
                 }
             ]
         }


### PR DESCRIPTION
socat offers a plethora of features, but we don't need most of them.

This configures socat with all features disabled, EXCEPT these:

- `--disable-unix`
- `--disable-ip4` [if we include this one, the build breaks :(]
- `--disable-listen`
- `--disable-retry`

I wish there was a way to have every feature disabled by default so that we would only enable the ones we need, but that's not possible.

This change also removes two unused installed executables (`filan` and `procan`), three scripts (`socat-{chain,broker,mux}.sh`), and a manpage.

---

I tested this by running [mpd-discord-rpc](https://github.com/JakeStanger/mpd-discord-rpc) first, and then on a separate window I ran Discord while enabling a few debug options for `socat`:

```
$ flatpak run --env=SOCAT_ARGS='-dd -v' com.discordapp.Discord 2>&1 | grep socat
2024/10/10 17:39:43 socat[4] N listening on AF=1 "/run/user/1000/app/com.discordapp.Discord/discord-ipc-0"
2024/10/10 17:39:43 socat[4] N accepting connection from AF=1 "<anon>" on AF=1 "/run/user/1000/app/com.discordapp.Discord/discord-ipc-0"
2024/10/10 17:39:43 socat[4] N forked off child process 19
2024/10/10 17:39:43 socat[4] N listening on AF=1 "/run/user/1000/app/com.discordapp.Discord/discord-ipc-0"
2024/10/10 17:39:43 socat[19] N opening connection to AF=1 "/run/user/1000/discord-ipc-0"
2024/10/10 17:39:43 socat[19] E connect(, AF=1 "/run/user/1000/discord-ipc-0", 30): Connection refused
2024/10/10 17:39:43 socat[19] N exit(1)
2024/10/10 17:39:43 socat[4] N childdied(): handling signal 17
2024/10/10 17:39:48 socat[4] N accepting connection from AF=1 "<anon>" on AF=1 "/run/user/1000/app/com.discordapp.Discord/discord-ipc-0"
2024/10/10 17:39:48 socat[4] N forked off child process 178
2024/10/10 17:39:48 socat[4] N listening on AF=1 "/run/user/1000/app/com.discordapp.Discord/discord-ipc-0"
2024/10/10 17:39:48 socat[178] N opening connection to AF=1 "/run/user/1000/discord-ipc-0"
2024/10/10 17:39:48 socat[178] N successfully connected from local address AF=1 "\xD4\xE6\xEB\x7E"
2024/10/10 17:39:48 socat[178] N starting data transfer loop with FDs [6,6] and [5,5]
....W...{"client_id":"677226551607033903","nonce":"4d69c3d8-9dbc-43cc-b80a-57bfe3c7a72c","v":1}
2024/10/10 17:39:48 socat[178] N write(5, 0x58e1647fd000, 95) completed
....y...{"cmd":"DISPATCH","data":{"v":1,"config":{"cdn_host":"cdn.discordapp.com","api_endpoint":"//discord.com/api","environment":"production"},"user":{"id":"<redacted>","username":"<redacted>","discriminator":"0","global_name":"<redacted>","avatar":"<redacted>","avatar_decoration_data":null,"bot":false,"flags":160,"premium_type":0}},"evt":"READY","nonce":null}
2024/10/10 17:39:48 socat[178] N write(6, 0x58e1647fd000, 385) completed
....e...{"cmd":"SET_ACTIVITY","args":{"pid":67719,"activity":{"state":"Slipknot / Vol. 3: The Subliminal Verses","details":"The Blister Exists","timestamps":{"start":1728592956},"assets":{"large_image":"https://coverartarchive.org/release-group/aa38e6f0-e748-35c8-a8d4-04ff660e9354/front-250","small_image":"notes"}}},"nonce":"dbbe3630-60c8-4819-a5c2-ccb820ffa4ce"}
2024/10/10 18:00:10 socat[178] N write(5, 0x58e1647fd000, 353) completed
........{"cmd":"SET_ACTIVITY","data":{"state":"Slipknot / Vol. 3: The Subliminal Verses","details":"Circle","timestamps":{"start":1728594009000},"assets":{"large_image":"mp:external/dEpexY-GPF0RYstHAdq8-zCwgONU9q7nrpx-4h-DJ5k/https/coverartarchive.org/release-group/aa38e6f0-e748-35c8-a8d4-04ff660e9354/front-250","small_image":"677249606572310582"},"name":"music","application_id":"677226551607033903","type":0},"evt":null,"nonce":"a8d81f0c-6133-4248-815a-d455dc04829c"}
2024/10/10 18:00:10 socat[178] N write(6, 0x58e1647fd000, 471) completed
2024/10/10 18:01:52 socat[178] N socket 2 (fd 5) is at EOF
2024/10/10 18:01:52 socat[4] N socat_signal(): handling signal 15
2024/10/10 18:01:52 socat[4] W exiting on signal 15
2024/10/10 18:01:52 socat[4] N socat_signal(): finishing signal 15
2024/10/10 18:01:52 socat[4] N exit(143)
2024/10/10 18:01:52 socat[178] N exiting with status 0
```

As you can see from the output above, socat is still successfully forwarding messages to Discord's socket.