### PR TITLE
Add external data checker for Discord (again)

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -79,9 +79,18 @@
             "sources": [
                 {
                     "type": "archive",
+                    "dest-filename": "discord.tar.gz",
                     "url": "https://dl.discordapp.net/apps/linux/0.0.71/discord-0.0.71.tar.gz",
                     "sha256": "3cc71abe05212fc735605696b28a1939b0daec03cca820f521acac103e5f59a7",
-                    "strip-components": 0
+                    "strip-components": 0,
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://discord.com/api/updates/stable?platform=linux",
+                        "version-query": ".name",
+                        "timestamp-query": ".pub_date",
+                        "url-query": "\"https://dl.discordapp.net/apps/linux/\\($version)/discord-\\($version).tar.gz\"",
+                        "is-main-source": true
+                    }
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
This was previously removed in 3ebfd7c0, due to the Flathub data checker bot opening multiple pull requests pointing to the same version.

That issue still exists when we use the "rotating-url" checker, but this new API uses the "JSON" checker instead, which allows us to only extract the version string from the JSON response, and then write our own, fixed download URL instead.