### PR TITLE
Inform people about when and where to report bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ flatpak install flathub com.discordapp.Discord
 flatpak run com.discordapp.Discord
 ```
 
+## Reporting bugs
+
+If you're experiencing a problem exclusive to the Flatpak version of Discord, i.e. it doesn't happen when running the official deb or tar.gz packages unsandboxed, feel free to open an issue about it here.
+
+Otherwise, please use the [official bug report form](https://support.discord.com/hc/en-us/articles/1500006052822-How-to-Report-a-Bug) instead, as it increases the chances of a bug getting fixed.
 
 ## Differences in flatpak version
 


### PR DESCRIPTION
Most bug reports here are related to crashes or missing features, which most of the times are caused by either Electron or Discord, and not Flatpak.

This change adds a new section to the README, asking users to first verify that the problem they're having is exclusive to the Flatpak package before opening a bug report, because if it's not, it should be reported directly to the Discord team instead, using their own bug report form.