### PR TITLE
Downgrade Discord to 0.0.74 from 0.0.75

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -66,11 +66,8 @@
   </supports>
   <update_contact>support@discordapp.com</update_contact>
   <releases>
-    <release version="0.0.75" date="2024-11-18">
-      <description></description>
-    </release>
     <release version="0.0.74" date="2024-11-12">
-      <description/>
+      <description></description>
     </release>
     <release version="0.0.73" date="2024-11-04">
       <description/>

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -112,17 +112,9 @@
                 {
                     "type": "archive",
                     "dest-filename": "discord.tar.gz",
-                    "url": "https://dl.discordapp.net/apps/linux/0.0.75/discord-0.0.75.tar.gz",
-                    "sha256": "9a4ab273d0a8f229de2fa75c24a691243e13546d516228fffce833321fed2c30",
-                    "strip-components": 0,
-                    "x-checker-data": {
-                        "type": "json",
-                        "url": "https://discord.com/api/updates/stable?platform=linux",
-                        "version-query": ".name",
-                        "timestamp-query": ".pub_date",
-                        "url-query": "\"https://dl.discordapp.net/apps/linux/\\($version)/discord-\\($version).tar.gz\"",
-                        "is-main-source": true
-                    }
+                    "url": "https://dl.discordapp.net/apps/linux/0.0.74/discord-0.0.74.tar.gz",
+                    "sha256": "c9fda02ef0e0cc5d77720a4a1628821c661547ea7b8d9380477ecbd45e8c66f7",
+                    "strip-components": 0
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Release 0.0.75 upgraded its Electron version to 32.2.2 from 32.0.0, which introduces a breaking change that broke the file chooser portal:

- https://github.com/electron/electron/issues/43819

The change has been reverted, but it hasn't been backported to the 32.x.y branch yet, and it's unclear when/if it will be.

So, until the situation is resolved, Discord is staying on 0.0.74.

Closes #479
Closes #480 