### PR TITLE
Avoid leaving our IPC socket in a broken state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /.flatpak-builder/
+/repo/

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -38,7 +38,6 @@
                 "--disable-stats",
                 "--disable-stdio",
                 "--disable-fdnum",
-                "--disable-file",
                 "--disable-creat",
                 "--disable-gopen",
                 "--disable-pipe",

--- a/discord.sh
+++ b/discord.sh
@@ -6,13 +6,26 @@ FLATPAK_ID=${FLATPAK_ID:-"com.discordapp.Discord"}
 OUR_SOCKET="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}/discord-ipc-0"
 DISCORD_SOCKET="${XDG_RUNTIME_DIR}/discord-ipc-0"
 
-rm -f "${OUR_SOCKET}"
+invoke_socat=true
+# Check if our socket already exists.
+if [ -S "${OUR_SOCKET}" ]
+then
+    # Check if socat is listening on it.
+    if socat "${SOCAT_ARGS[@]}" -u OPEN:/dev/null "UNIX-CONNECT:${OUR_SOCKET}"
+    then
+        # socat is still listening on it, make sure not not invoke it again.
+        invoke_socat=false
+    else
+        # Socket exists but socat is not listening on it (for whatever reason), delete it so we can invoke socat again.
+        rm -f "${OUR_SOCKET}"
+    fi
+fi
 
-socat "${SOCAT_ARGS[@]}" \
-    "UNIX-LISTEN:${OUR_SOCKET},forever,fork" \
-    "UNIX-CONNECT:${DISCORD_SOCKET}" \
-    &
-socat_pid=$!
+if [ "${invoke_socat}" = true ]
+then
+    socat "${SOCAT_ARGS[@]}" "UNIX-LISTEN:${OUR_SOCKET},forever,fork" "UNIX-CONNECT:${DISCORD_SOCKET}" &
+    socat_pid=$!
+fi
 
 if [ -f "${XDG_CONFIG_HOME}/discord-flags.conf" ]
 then
@@ -28,4 +41,8 @@ fi
 
 disable-breaking-updates.py
 env TMPDIR="${XDG_CACHE_HOME}" zypak-wrapper /app/discord/Discord --enable-speech-dispatcher "${FLAGS[@]}" "$@"
-kill -SIGTERM $socat_pid
+
+if [ "${invoke_socat}" = true ]
+then
+    kill -SIGTERM "${socat_pid}"
+fi

--- a/discord.sh
+++ b/discord.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
+
+read -ra SOCAT_ARGS <<<"${SOCAT_ARGS}"
+
 FLATPAK_ID=${FLATPAK_ID:-"com.discordapp.Discord"}
 OUR_SOCKET="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}/discord-ipc-0"
 DISCORD_SOCKET="${XDG_RUNTIME_DIR}/discord-ipc-0"
 
 rm -f "${OUR_SOCKET}"
 
-socat ${SOCAT_ARGS} \
+socat "${SOCAT_ARGS[@]}" \
     "UNIX-LISTEN:${OUR_SOCKET},forever,fork" \
     "UNIX-CONNECT:${DISCORD_SOCKET}" \
     &
@@ -24,5 +27,5 @@ then
 fi
 
 disable-breaking-updates.py
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/discord/Discord --enable-speech-dispatcher "${FLAGS[@]}" "$@"
+env TMPDIR="${XDG_CACHE_HOME}" zypak-wrapper /app/discord/Discord --enable-speech-dispatcher "${FLAGS[@]}" "$@"
 kill -SIGTERM $socat_pid


### PR DESCRIPTION
With these changes, we do a couple of extra checks to avoid leaving our IPC socket in a broken state:

Before invoking `socat`, we check if our socket exists and if `socat` is listening on it. If it is, we skip invoking `socat` to avoid breaking stuff. But if our socket doesn't exist (or it does but `socat` is not listening on it), we remove the socket and invoke `socat` again.

This helps in at least two scenarios:

#### Scenario 1: Our socket would be accidentally removed upon trying to invoke Discord while it was already running.

If you tried to launch two Discord instances, which you can easily do by accident if you leave Discord running in the background and then try to launch it again through the applications menu of your desktop environment, our socket would be removed unconditionally (see commit: ["Always remove socket file before invoking socat"](https://github.com/flathub/com.discordapp.Discord/commit/61fdd74e2be4454fd55942c9854e6471d01bdd56)).

I didn't think that was a problem because we would invoke `socat` in the second Discord instance anyway, so our socket would be recreated. However, that's not the case: Discord checks if there's an instance of itself already running, and if it does, it will terminate the most recent instance, not the oldest one. This behavior would cause `socat` to be terminated on the second instance, thereby removing our socket and leaving the first Discord instance broken.

#### Scenario 2: Our socket would be lingering if our Flatpak instance got killed externally.

The easiest way to reproduce this, is by running `flatpak kill com.discordapp.Discord` while Discord is running. That will kill the entire Flatpak instance of Discord, but it will not remove our socket.

Then, if we try to launch Discord again, `socat` will be invoked but it will fail with an error:

`2024/10/03 16:21:27 socat[4] E "/run/user/1000/app/com.discordapp.Discord/discord-ipc-0" exists`

That's actually why I introduced the commit above, but as I also explained above, removing our socket unconditionally before invoking `socat`  causes bad side effects too...

Now, with these changes, we should at least avoid these two scenarios.
