### PR TITLE
Allow passing a list of URLs to the executable program

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -102,7 +102,7 @@
                 "chmod +x /app/discord/Discord",
                 "install -d /app/share/applications",
                 "install -Dm644 /app/discord/discord.desktop /app/share/applications/${FLATPAK_ID}.desktop",
-                "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord --set-key=Exec --set-value=com.discordapp.Discord --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord --set-key=Exec --set-value='com.discordapp.Discord %U' --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 /app/discord/discord.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png",
                 "install -Dm644 com.discordapp.Discord.appdata.xml /app/share/appdata/com.discordapp.Discord.appdata.xml",
                 "patch-desktop-filename ${FLATPAK_DEST}/discord/resources/app.asar"


### PR DESCRIPTION
With these changes it is now possible to pass a list of URLs to discord following this spec: https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html

I believe it was accidentally omitted from this PR: https://github.com/flathub/com.discordapp.Discord/pull/391

I encountered this issue while using Discord's GameSDK. It throws an error message `... <path-to-.desktop> contains supported protocols but doesn't use %u or %U in its Exec line! This is inconsistent.`