### PR TITLE
Update Discord to 0.0.87 

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -66,8 +66,11 @@
   </supports>
   <update_contact>support@discordapp.com</update_contact>
   <releases>
-    <release version="0.0.74" date="2024-11-12">
+    <release version="0.0.87" date="2025-02-24">
       <description></description>
+    </release>
+    <release version="0.0.74" date="2024-11-12">
+      <description/>
     </release>
     <release version="0.0.73" date="2024-11-04">
       <description/>

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -111,9 +111,17 @@
                 {
                     "type": "archive",
                     "dest-filename": "discord.tar.gz",
-                    "url": "https://dl.discordapp.net/apps/linux/0.0.74/discord-0.0.74.tar.gz",
-                    "sha256": "c9fda02ef0e0cc5d77720a4a1628821c661547ea7b8d9380477ecbd45e8c66f7",
-                    "strip-components": 0
+                    "url": "https://dl.discordapp.net/apps/linux/0.0.87/discord-0.0.87.tar.gz",
+                    "sha256": "db63e2e6b2347eeec0fd9a2a92320e0ed12798d42dd291419aca6587440ad004",
+                    "strip-components": 0,
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://discord.com/api/updates/stable?platform=linux",
+                        "version-query": ".name",
+                        "timestamp-query": ".pub_date",
+                        "url-query": "\"https://dl.discordapp.net/apps/linux/\\($version)/discord-\\($version).tar.gz\"",
+                        "is-main-source": true
+                    }
                 },
                 {
                     "type": "file",

--- a/discord.sh
+++ b/discord.sh
@@ -36,7 +36,8 @@ WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 
 if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
-    FLAGS+=('--enable-features=WaylandWindowDecorations' '--ozone-platform-hint=auto')
+    # TODO: Investigate removing --disable-gpu-memory-buffer-video-frames once Discord updates to Electron 34+ (https://crbug.com/331796411)
+    FLAGS+=('--enable-features=WaylandWindowDecorations' '--ozone-platform-hint=auto' '--disable-gpu-memory-buffer-video-frames')
 fi
 
 disable-breaking-updates.py


### PR DESCRIPTION
This PR updates Discord to ~0.0.86~ 0.0.87 ~and enables the Wayland socket by default, which is required for screen sharing to work on Wayland.~

**EDIT:** The Wayland change was reverted due to a bug that prevents GNOME users on Wayland from resizing Discord's main window (likely an Electron bug: https://github.com/electron/electron/issues/44543).

We will revisit enabling Wayland by default in the future. For now, users are still required [to enable Wayland support manually](https://github.com/flathub/com.discordapp.Discord?tab=readme-ov-file#wayland).

### For testers

If you encounter any issues while running the test build, please post the entire output of `flatpak run com.discordapp.Discord//test`, and also post your system information, for example:

```
**CPU:** Intel Core i9 14900K
**GPU:** NVIDIA RTX 4080
**Driver:** 570.86.16
**OS**: Fedora 41
**Kernel**: 6.12.13
**Desktop environment:** GNOME 47 on Wayland
```

---

I'll be sharing below some relevant information related to Discord and Wayland, based on my own testing.

Test machine:

- **CPU:** AMD Ryzen 7 5700U with Radeon Graphics
- **OS**: CachyOS Linux
- **Kernel**: 6.13.3-2-cachyos
- **Desktop environment:** KDE Plasma 6.3.1 (Qt 6.8.2) on Wayland

### Notes

• I tried replacing the `--socket=x11` Flatpak permission with `--socket=fallback-x11`, but that causes Discord's render process to always crash (i.e., Discord never gets past its splash screen):

<details>
  <summary><b>Logs</b></summary>

```
Discord 0.0.86
Starting app.
Starting updater.
2/19/2025, 8:37:28 PM GMT-3 [Modules] Modules initializing
2/19/2025, 8:37:28 PM GMT-3 [Modules] Distribution: remote
2/19/2025, 8:37:28 PM GMT-3 [Modules] Host updates: disabled
2/19/2025, 8:37:28 PM GMT-3 [Modules] Module updates: enabled
2/19/2025, 8:37:28 PM GMT-3 [Modules] Module install path: /home/user/.var/app/com.discordapp.Discord/config/discord/0.0.86/modules
2/19/2025, 8:37:28 PM GMT-3 [Modules] Module installed file path: /home/user/.var/app/com.discordapp.Discord/config/discord/0.0.86/modules/installed.json
2/19/2025, 8:37:28 PM GMT-3 [Modules] Module download path: /home/user/.var/app/com.discordapp.Discord/config/discord/0.0.86/modules/pending
splashScreen.initSplash(false)
CDM component API found
blackbox: 2/19/2025, 8:37:29 PM GMT-3 0

----------------------------------------------
CDM completed with status: cdm-ready-success
blackbox: 2/19/2025, 8:37:29 PM GMT-3 1 Discord starting: {"releaseChannel":"stable","version":"0.0.86"}, modulepath: /home/user/.var/app/com.discordapp.Discord/config/discord/0.0.86/modules
blackbox: 2/19/2025, 8:37:29 PM GMT-3 2 ✅ webContents.created web1 ""
blackbox: 2/19/2025, 8:37:29 PM GMT-3 3 ✅ window.created win1 "discord"
20:37:29.230 › DiscordSplash.signalReady
splashScreen: SPLASH_SCREEN_READY
2/19/2025, 8:37:29 PM GMT-3 [Modules] No updates to install
splashScreen: no-pending-updates
2/19/2025, 8:37:29 PM GMT-3 [Modules] Host is up to date.
2/19/2025, 8:37:29 PM GMT-3 [Modules] Checking for module updates at https://discord.com/api/modules/stable/versions.json
splashScreen: checking-for-updates
splashScreen.updateSplashState checking-for-updates checking-for-updates {}
splashScreen.webContentsSend: SPLASH_UPDATE_STATE SPLASH_UPDATE_STATE [ { status: 'checking-for-updates' } ]
20:37:29.278 › DiscordSplash.onStateUpdate: {"status":"checking-for-updates"}
20:37:29.279 › Splash.onStateUpdate: {"status":"checking-for-updates"}
blackbox: 2/19/2025, 8:37:29 PM GMT-3 4 ✅ webContents.did-finish-load web1
2/19/2025, 8:37:29 PM GMT-3 [Modules] No module updates available.
splashScreen: update-check-finished true 0 false
splashScreen.launchMainWindow: false
Optional module ./ElectronTestRpc was not included.
splashScreen.updateSplashState launching launching {}
splashScreen.webContentsSend: SPLASH_UPDATE_STATE SPLASH_UPDATE_STATE [ { status: 'launching' } ]
blackbox: 2/19/2025, 8:37:29 PM GMT-3 5 ✅ webContents.created web2 ""
20:37:29.417 › DiscordSplash.onStateUpdate: {"status":"launching"}
20:37:29.418 › Splash.onStateUpdate: {"status":"launching"}
blackbox: 2/19/2025, 8:37:29 PM GMT-3 6 ✅ window.created win2 "Discord"
20:37:30.229 › Initializing voice engine with audio subsystem: standard
20:37:30.230 › Splash.updateCountdownSeconds: undefined
20:37:31.230 › Splash.updateCountdownSeconds: undefined
20:37:32.229 › Splash.updateCountdownSeconds: undefined
[WebContents] crashed (reason: crashed, exitCode: 139)... reloading
Optional module ./ElectronTestRpc was not included.
blackbox: 2/19/2025, 8:37:32 PM GMT-3 7 ❌ render-process-gone { reason: 'crashed', exitCode: 139 }
blackbox: 2/19/2025, 8:37:32 PM GMT-3 8 window.closed win2
blackbox: 2/19/2025, 8:37:32 PM GMT-3 9 ✅ webContents.created web3 ""
blackbox: 2/19/2025, 8:37:32 PM GMT-3 10 ✅ window.created win3 "Discord"
blackbox: 2/19/2025, 8:37:32 PM GMT-3 11 webContents.destroyed web2
20:37:32.926 › Initializing voice engine with audio subsystem: standard
20:37:33.229 › Splash.updateCountdownSeconds: undefined
20:37:34.230 › Splash.updateCountdownSeconds: undefined
[WebContents] double crashed (reason: crashed, exitCode: 139)... RIP =(
blackbox: 2/19/2025, 8:37:34 PM GMT-3 12 ❌ render-process-gone { reason: 'crashed', exitCode: 139 }
blackbox: 2/19/2025, 8:37:34 PM GMT-3 13 before-quit
[5:0219/133734.755699:ERROR:wayland_event_watcher.cc(47)] libwayland: warning: queue 0x2ed400e3ae40 destroyed while proxies still attached:

[5:0219/133734.755808:ERROR:wayland_event_watcher.cc(47)] libwayland:   wl_shm_pool#44 still attached
```
</details>

The render process hard-crashes with `SIGSEGV`, apparently after trying to know if an X11 extension exists (but it ends up using an invalid display handle):

<details>
  <summary><b>gdb backtrace</b></summary>

```sh
$ coredumpctl list
TIME                          PID  UID  GID SIG     COREFILE EXE                   SIZE
Wed 2025-02-19 20:37:34 -03 28785 1000 1000 SIGSEGV present  /app/discord/Discord 19.7M
```

```cpp
$ flatpak-coredumpctl -m 28785 com.discordapp.Discord
Program terminated with signal SIGSEGV, Segmentation fault.
#0  XQueryExtension (dpy=0x0, name=0x7fb8d22b8940 "XInputExtension",
    major_opcode=0x7fb8d22e7d60 <discord::input::mInputEventExtCode>, first_event=0x7fb8bfbfa3b4,
    first_error=0x7fb8bfbfa3b0) at ../../src/QuExt.c:48
48          LockDisplay(dpy);
[Current thread is 1 (Thread 0x7fb8bfbff6c0 (LWP 226))]
(gdb) bt
#0  XQueryExtension
    (dpy=0x0, name=0x7fb8d22b8940 "XInputExtension", major_opcode=0x7fb8d22e7d60 <discord::input::mInputEventExtCode>, first_event=0x7fb8bfbfa3b4, first_error=0x7fb8bfbfa3b0) at ../../src/QuExt.c:48
#1  0x00007fb8d226df2d in discord::input::InputEvents::PlatformInitialize (loop=...)
    at ./discord_desktop/build_x64/../../discord_desktop/native_modules/discord_utils/src/input_events_linux.cpp:122
#2  0x00007fb8d2209f96 in discord::input::InputEvents::Initialize (eventLoop=...)
    at ./discord_desktop/build_x64/../../discord_desktop/native_modules/discord_utils/src/input_events.cpp:211
#3  0x00007fb8d22207e6 in (anonymous namespace)::CreateWorker()::$_1::operator()() const (this=<optimized out>)
    at ./discord_desktop/build_x64/../../discord_desktop/native_modules/discord_utils/src/utils_bindings.cpp:71
#4  discord::uv::Executor::ExecuteBlocking<(anonymous namespace)::CreateWorker()::$_1>((anonymous namespace)::CreateWorker()::$_1&&)::{lambda()#1}::operator()() const (this=0xf1401a21b28) at ../../discord_common/native/uv/executor.h:52
#5  discord::uv::Task<discord::uv::Executor::ExecuteBlocking<(anonymous namespace)::CreateWorker()::$_1>((anonymous namespace)::CreateWorker()::$_1&&)::{lambda()#1}>::Run() (this=0xf1401a21b20) at ../../discord_common/native/uv/executor.h:29
#6  0x00007fb8d2272809 in discord::uv::Executor::ExecutePending (this=<optimized out>)
    at ./discord_desktop/build_x64/../../discord_common/native/uv/executor.cpp:140
#7  0x00005c7e2ab126f8 in ??? ()
```
</details>

So, at least for now, it looks like we must have both `--socket=x11` and `--socket=wayland`.

---

• I added the `--disable-gpu-memory-buffer-video-frames` Chromium launch option to Discord's launch options (on Wayland only), in order to prevent the system journal from being *heavily* spammed with these two error messages while screen sharing:

```
[65:0219/130307.530052:ERROR:gbm_pixmap_wayland.cc(82)] Cannot create bo with format= YUV_420_BIPLANAR and usage=SCANOUT_CPU_READ_WRITE
[65:0219/130307.530052:ERROR:gpu_channel.cc(503)] Buffer Handle is null.
```

To be clear, they would only pop up while I sharing my entire screen *and* when Discord's main window was brought to the foreground.

In any case, it looks like that's [a real Chromium bug](https://issues.chromium.org/issues/331796411), which [has been fixed in M-131](https://chromium.googlesource.com/chromium/src.git/+/000064171db044f98d1c9e025e16007d8269e26a%5E!/). However, Discord 0.0.86 uses Electron 33, which in turn includes Chromium M-130. We can investigate removing this launch option in future Discord updates.

---

• While I was screen sharing my test machine's desktop to another local computer I have, I noticed that the video stream would occasionally replay past frames (which is quite annoying), especially when the content being dispayed wouldn't trigger a repaint of the entire screen (e.g. non-gaming content). I couldn't find a solution or workaround for that.

---

Closes #89
Closes #380
Closes #483
