### PR TITLE
Update icon following brand and Flathub guidelines

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -103,7 +103,7 @@
                 "install -d /app/share/applications",
                 "install -Dm644 /app/discord/discord.desktop /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord --set-key=Exec --set-value='com.discordapp.Discord %U' --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
-                "install -Dm644 /app/discord/discord.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png",
+                "install -Dm644 com.discordapp.Discord.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
                 "install -Dm644 com.discordapp.Discord.appdata.xml /app/share/appdata/com.discordapp.Discord.appdata.xml",
                 "patch-desktop-filename ${FLATPAK_DEST}/discord/resources/app.asar"
             ],
@@ -130,6 +130,10 @@
                 {
                     "type": "file",
                     "path": "com.discordapp.Discord.appdata.xml"
+                },
+                {
+                    "type": "file",
+                    "path": "com.discordapp.Discord.svg"
                 },
                 {
                     "type": "file",

--- a/com.discordapp.Discord.svg
+++ b/com.discordapp.Discord.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128.00002"
+   height="127.99999"
+   viewBox="0 0 33.866671 33.866665"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   sodipodi:docname="discord.svg"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="currentColor"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     inkscape:zoom="4.6093764"
+     inkscape:cx="74.196588"
+     inkscape:cy="41.220327"
+     inkscape:window-width="1728"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" /><defs
+     id="defs1"><style
+       id="style1">.cls-1{fill:#e0e3ff;}</style></defs><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-32.279167,-138.64166)"><g
+       id="g1"
+       transform="matrix(0.4,0,0,0.4,-10.202805,47.397978)"><circle
+         style="opacity:1;fill:#5865f2;fill-opacity:1;stroke-width:48.5099;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;paint-order:stroke fill markers"
+         id="path1"
+         cx="148.53827"
+         cy="270.44254"
+         r="39.6875" /><path
+         id="Discord-Symbol-Light_Blurple"
+         class="cls-1"
+         d="m 155.90857,250.59878 c -0.51164,0.90839 -0.97106,1.84811 -1.38869,2.80872 -3.96772,-0.59514 -8.00853,-0.59514 -11.98666,0 -0.40721,-0.96061 -0.87709,-1.90033 -1.38869,-2.80872 -3.72757,0.63693 -7.36116,1.75414 -10.80678,3.33078 -6.82865,10.11766 -8.67676,19.97424 -7.75792,29.69512 3.99901,2.95491 8.47837,5.21024 13.25005,6.65115 1.07545,-1.44091 2.02563,-2.97579 2.84005,-4.57328 -1.54533,-0.57429 -3.03845,-1.29474 -4.46889,-2.13004 0.37587,-0.27149 0.74133,-0.55339 1.09632,-0.82488 8.3844,3.94685 18.09486,3.94685 26.48967,0 0.355,0.29236 0.72046,0.57427 1.09633,0.82488 -1.43045,0.84572 -2.92356,1.55575 -4.47931,2.14049 0.81442,1.5975 1.76456,3.13237 2.84005,4.57328 4.77155,-1.44091 9.25087,-3.68581 13.25021,-6.64068 1.08562,-11.27665 -1.8587,-21.04975 -7.77916,-29.7056 -3.435,-1.57661 -7.0686,-2.69386 -10.79616,-3.32035 z m -16.06922,27.04306 c -2.57899,0 -4.71947,-2.33888 -4.71947,-5.23112 0,-2.8922 2.05693,-5.24154 4.70905,-5.24154 2.65212,0 4.76122,2.35976 4.71947,5.24154 -0.0417,2.88181 -2.07781,5.23112 -4.70905,5.23112 z m 17.39528,0 c -2.58949,0 -4.70905,-2.33888 -4.70905,-5.23112 0,-2.8922 2.05693,-5.24154 4.70905,-5.24154 2.65212,0 4.7508,2.35976 4.709,5.24154 -0.0418,2.88181 -2.0778,5.23112 -4.709,5.23112 z"
+         style="stroke-width:0.413411" /></g></g></svg>


### PR DESCRIPTION
This switches from using the icon shipped in the upstream tarball to a scalable icon that follows both the [Discord brand guidelines] and the [Flathub quality guidelines]. Specifically, it:

- uses the official assets and colors
- follows [App & Social Icons] alignment
- matches the Flathub icon template sizing for a circle icon

Fixes #508

[Discord brand guidelines]: https://discord.com/branding
[Flathub quality guidelines]: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#reasonable-footprint
[App & Social Icons]: https://my.corebook.io/1zObrQ89Q4wHhgFCfYIUhMUvmNf4XjxO/02-logo/symbol?m=6596076