### PR TITLE
Update summary to match other app store listings

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -5,7 +5,7 @@
   <developer id="com.discord">
     <name>Discord Inc.</name>
   </developer>
-  <summary>Messaging, voice and video client</summary>
+  <summary>Talk, play, hang out</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://discord.com</url>


### PR DESCRIPTION
…while also considering the Flathub quality guidelines (namely: sentence case).

Discord uses "Talk, Play, Hang Out" across both the [Apple App Store] and [Google Play Store]. I considered "Group chat that’s all fun & games" which is used on their home page, but I'm not sure if that would pass the Flathub guidelines.

[Apple App Store]: https://apps.apple.com/us/app/discord-talk-play-hang-out/id985746746
[Google Play Store]: https://play.google.com/store/apps/details?id=com.discord