### PR TITLE
Update Discord to 0.0.94 and enable Wayland by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,20 @@ However, this sandboxing prevents the following features from working:
 
 ### Wayland
 
-This package enables the flags to run on Wayland, however it is opt-in. To opt-in run:
+Wayland support is enabled by default since Discord 0.0.94 (released in 2025-05-05).
 
-```sh
-flatpak override --user --socket=wayland com.discordapp.Discord
+Please note that native window decorations are not enabled by default. To do so, add the following lines to your [persistent launch options](#persistent-launch-options):
+
+```
+--enable-features=WaylandWindowDecorations
+--ozone-platform-hint=auto
 ```
 
-To opt-out do the same with `--nosocket=wayland`.
+To disable Wayland support permanently, run:
+
+```
+flatpak override --user --nosocket=wayland com.discordapp.Discord
+```
 
 ### Persistent launch options
 

--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -62,8 +62,11 @@
   </supports>
   <update_contact>support@discordapp.com</update_contact>
   <releases>
-    <release version="0.0.93" date="2025-04-29">
+    <release version="0.0.94" date="2025-05-05">
       <description></description>
+    </release>
+    <release version="0.0.93" date="2025-04-29">
+      <description/>
     </release>
     <release version="0.0.92" date="2025-04-22">
       <description/>

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -111,8 +111,8 @@
                 {
                     "type": "archive",
                     "dest-filename": "discord.tar.gz",
-                    "url": "https://dl.discordapp.net/apps/linux/0.0.93/discord-0.0.93.tar.gz",
-                    "sha256": "fc24e0456322ed19ec22bcd6ad71c4e43f7316d7bb1a0aa29b19ef2538f78456",
+                    "url": "https://dl.discordapp.net/apps/linux/0.0.94/discord-0.0.94.tar.gz",
+                    "sha256": "d37e677db132bddb0dc5987a7e45e1d89858ec45d0b705274b8b142abef83114",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "json",

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -12,6 +12,7 @@
     ],
     "finish-args": [
         "--share=ipc",
+        "--socket=wayland",
         "--socket=x11",
         "--socket=pcsc",
         "--socket=pulseaudio",

--- a/discord.sh
+++ b/discord.sh
@@ -36,8 +36,7 @@ WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 
 if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
-    # TODO: Investigate removing --disable-gpu-memory-buffer-video-frames once Discord updates to Electron 34+ (https://crbug.com/331796411)
-    FLAGS+=('--enable-features=WaylandWindowDecorations' '--ozone-platform-hint=auto' '--disable-gpu-memory-buffer-video-frames')
+    FLAGS+=('--enable-features=WaylandWindowDecorations' '--ozone-platform-hint=auto')
 fi
 
 disable-breaking-updates.py

--- a/discord.sh
+++ b/discord.sh
@@ -32,13 +32,6 @@ then
     mapfile -t FLAGS <<< "$(grep -Ev '^\s*$|^#' "${XDG_CONFIG_HOME}/discord-flags.conf")"
 fi
 
-WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
-
-if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
-then
-    FLAGS+=('--enable-features=WaylandWindowDecorations' '--ozone-platform-hint=auto')
-fi
-
 disable-breaking-updates.py
 env TMPDIR="${XDG_CACHE_HOME}" zypak-wrapper /app/discord/Discord --enable-speech-dispatcher "${FLAGS[@]}" "$@"
 


### PR DESCRIPTION
In my experience, Discord on Wayland has been working great for quite some time now (at least on KDE 6.3), so I think we'll be doing everyone a favor by enabling Wayland by default. Having the Wayland socket available is mandatory for Discord's screen sharing feature to work on Wayland sessions.

The X11 socket can't be removed just yet, because without it Discord's render process just crashes continuously on its splash screen. And also because I had to remove the experimental launch options that enable native Wayland decorations, because they currently cause problems with the window decoration shadows on GNOME 48 (see https://github.com/flathub/com.discordapp.Discord/pull/517#issuecomment-2852328622).

Closes #502