### PR TITLE
manifest: Update `StartupWMClass` to `discord-stable` in desktop file 

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -100,8 +100,6 @@
                 "install -Dm755 discord.sh /app/bin/com.discordapp.Discord",
                 "install -Dm755 disable-breaking-updates.py /app/bin",
                 "mv Discord /app/discord",
-                "chmod +x /app/discord/Discord",
-                "install -d /app/share/applications",
                 "install -Dm644 /app/discord/discord.desktop /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord --set-key=Exec --set-value='com.discordapp.Discord %U' --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 com.discordapp.Discord.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -101,9 +101,13 @@
                 "install -Dm755 disable-breaking-updates.py /app/bin",
                 "mv Discord /app/discord",
                 "install -Dm644 /app/discord/discord.desktop /app/share/applications/${FLATPAK_ID}.desktop",
-                "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord --set-key=Exec --set-value='com.discordapp.Discord %U' --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 com.discordapp.Discord.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
-                "install -Dm644 com.discordapp.Discord.appdata.xml /app/share/appdata/com.discordapp.Discord.appdata.xml",
+                "install -Dm644 com.discordapp.Discord.appdata.xml /app/share/appdata/com.discordapp.Discord.appdata.xml"
+            ],
+            "post-install": [
+                "desktop-file-edit --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --set-key=Exec --set-value='com.discordapp.Discord %U' /app/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "patch-desktop-filename ${FLATPAK_DEST}/discord/resources/app.asar"
             ],
             "sources": [

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -108,6 +108,7 @@
                 "desktop-file-edit --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Exec --set-value='com.discordapp.Discord %U' /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord /app/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --remove-key=Path /app/share/applications/${FLATPAK_ID}.desktop",
                 "patch-desktop-filename ${FLATPAK_DEST}/discord/resources/app.asar"
             ],
             "sources": [

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -108,6 +108,7 @@
                 "desktop-file-edit --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Exec --set-value='com.discordapp.Discord %U' /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord /app/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --set-key=StartupWMClass --set-value=discord-stable /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --remove-key=Path /app/share/applications/${FLATPAK_ID}.desktop",
                 "patch-desktop-filename ${FLATPAK_DEST}/discord/resources/app.asar"
             ],


### PR DESCRIPTION
As of release 0.0.105, Discord devs changed the `WM_CLASS` property of the updater window and main window from `discord` to `discord-stable`, but they forgot to also update the StartupWMClass key in the desktop file.

Having mismatched `StartupWMClass` and `WM_CLASS` values, can cause window association issues.

Fixes #549