### PR TITLE
discord: Update discord.tar.gz to 0.0.106

### DIFF
--- a/com.discordapp.Discord.appdata.xml
+++ b/com.discordapp.Discord.appdata.xml
@@ -62,8 +62,11 @@
   </supports>
   <update_contact>support@discordapp.com</update_contact>
   <releases>
-    <release version="0.0.105" date="2025-08-19">
+    <release version="0.0.106" date="2025-08-20">
       <description></description>
+    </release>
+    <release version="0.0.105" date="2025-08-19">
+      <description/>
     </release>
     <release version="0.0.104" date="2025-08-04">
       <description/>

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -108,7 +108,6 @@
                 "desktop-file-edit --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Exec --set-value='com.discordapp.Discord %U' /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord /app/share/applications/${FLATPAK_ID}.desktop",
-                "desktop-file-edit --set-key=StartupWMClass --set-value=discord-stable /app/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --remove-key=Path /app/share/applications/${FLATPAK_ID}.desktop",
                 "patch-desktop-filename ${FLATPAK_DEST}/discord/resources/app.asar"
             ],
@@ -116,8 +115,8 @@
                 {
                     "type": "archive",
                     "dest-filename": "discord.tar.gz",
-                    "url": "https://dl.discordapp.net/apps/linux/0.0.105/discord-0.0.105.tar.gz",
-                    "sha256": "fc2700ab892cdbf19e4c0b13bdf00300d0931574a1fc6901d2766d61c45786ed",
+                    "url": "https://dl.discordapp.net/apps/linux/0.0.106/discord-0.0.106.tar.gz",
+                    "sha256": "16a6363bb11a1235743bcfff8c85b52b8b5348f2c0a4bc406c79b0e38d3679eb",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "json",


### PR DESCRIPTION
This updates Discord to version 0.0.106 and it also reverts commit 7c3ee86a ("manifest: Update "StartupWMClass" to "discord-stable" in desktop file"), because Discord devs reverted the change that sets the `WM_CLASS` window property to `discord-stable`.

Here's the relevant diff between 0.0.105 (before) and 0.0.106 (after):

```diff
diff --git a/app_bootstrap/bootstrap.js b/app_bootstrap/bootstrap.js
index 09319eb..b5da2a1 100644
--- a/app_bootstrap/bootstrap.js
+++ b/app_bootstrap/bootstrap.js
@@ -21,7 +21,9 @@ const sentry = require('@sentry/electron');
 const logger = require('./logger');
 app.setVersion(buildInfo.version);
 global.releaseChannel = buildInfo.releaseChannel;
-app.setName(app.getName() + '-' + buildInfo.releaseChannel);
+if (buildInfo.releaseChannel !== 'stable' && process.platform === 'linux') {
+  app.setName(app.getName() + '-' + buildInfo.releaseChannel);
+}
 const errorHandler = require('./errorHandler');
 errorHandler.init();
 const paths = require('../common/paths');
```