### PR TITLE
Revert "Update runtime to 25.08"

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.discordapp.Discord",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "25.08",
+    "base-version": "24.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "25.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "com.discordapp.Discord",
     "separate-locales": false,


### PR DESCRIPTION
A bug in the 25.08 runtime seems to have broken font loading:

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1900

This reverts commit 62b3a9a407ab6f556836e3e15cb829476528845c.

Fixes #556