### PR TITLE
Add filesystem access for PipeWire

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -22,6 +22,7 @@
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-pictures:ro",
         "--filesystem=xdg-download",
+        "--filesystem=xdg-run/pipewire-0",
         "--filesystem=xdg-run/speech-dispatcher",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=com.canonical.AppMenu.Registrar",


### PR DESCRIPTION
Follow-up to Discord Canary change ([pull request](https://github.com/flathub/com.discordapp.DiscordCanary/pull/682)) to expose pipewire access for SteamDeck-specific support. 

We're seeing promising CPU performance improvements on SteamDeck in limited testing, and would like to open the experiment to a broader audience. 