### PR TITLE
Update runtime to 25.08

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.discordapp.Discord",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "24.08",
+    "base-version": "25.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "24.08",
+    "runtime-version": "25.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "com.discordapp.Discord",
     "separate-locales": false,


### PR DESCRIPTION
The first attempt at this, was with commit 62b3a9a4, but it was reverted shortly after, with commit 7bad511e, due to a runtime bug regarding [missing fonts](https://github.com/flathub/com.discordapp.Discord/issues/556) in some desktop configurations.

The bug has been fixed since then, so we can try this again.

