### PR TITLE
Remove PipeWire permissions

### DIFF
--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -22,7 +22,6 @@
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-pictures:ro",
         "--filesystem=xdg-download",
-        "--filesystem=xdg-run/pipewire-0",
         "--filesystem=xdg-run/speech-dispatcher",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=com.canonical.AppMenu.Registrar",


### PR DESCRIPTION
Screensharing uses the XDG portal, webcams go through `device=all`, and sound goes through PulseAudio, so there is no reason for Discord to access the PipeWire socket.