### PR TITLE
Make Speech Dispatcher support opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ To undo that, run:
 rm ~/.config/autostart/com.discordapp.Discord.desktop
 ```
 
+### Enabling text to speech support
+
+Chromium includes support for [Speech Dispatcher](https://github.com/brailcom/speechd), but it's currently opt-in. To enable it, run these two commands:
+
+```sh
+# Add the required permission
+flatpak override --user --filesystem=xdg-run/speech-dispatcher:ro com.discordapp.Discord
+# Add the required launch option
+echo '--enable-speech-dispatcher' >> ~/.var/app/com.discordapp.Discord/config/discord-flags.conf
+```
+
+Please note that you will also need a speech synthesizer installed (e.g. [Piper](https://github.com/OHF-Voice/piper1-gpl), [Festival](https://www.cstr.ed.ac.uk/projects/festival/), [eSpeak NG](https://github.com/espeak-ng/espeak-ng)), and at least version 0.12.0 of Speech Dispatcher for this setup to work seamlessly. The [Arch Wiki](https://wiki.archlinux.org/title/Speech_dispatcher) can also be helpful to set this up properly.
+
 ## Legal
 
 The Discord app itself is **proprietary** (closed source).

--- a/com.discordapp.Discord.json
+++ b/com.discordapp.Discord.json
@@ -23,7 +23,6 @@
         "--filesystem=xdg-pictures:ro",
         "--filesystem=xdg-download",
         "--filesystem=xdg-run/pipewire-0",
-        "--filesystem=xdg-run/speech-dispatcher",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=com.canonical.AppMenu.Registrar",
         "--talk-name=com.canonical.indicator.application",

--- a/discord.sh
+++ b/discord.sh
@@ -46,7 +46,7 @@ then
     fi
 fi
 
-env TMPDIR="${XDG_CACHE_HOME}" ZYPAK_DISABLE_SANDBOX=1 zypak-wrapper "${XDG_CONFIG_HOME}/discord/${app_dir:-}/Discord" --enable-speech-dispatcher "${FLAGS[@]}" "$@"
+env TMPDIR="${XDG_CACHE_HOME}" ZYPAK_DISABLE_SANDBOX=1 zypak-wrapper "${XDG_CONFIG_HOME}/discord/${app_dir:-}/Discord" "${FLAGS[@]}" "$@"
 
 if [ "${invoke_socat}" = true ]
 then


### PR DESCRIPTION
The `--enable-speech-dispatcher` launch option comes from Chromium and it's [considered experimental](https://github.com/flathub/com.discordapp.Discord/issues/621) (thus, it's also opt-in).

Additionally, this launch option can make Discord [completely unusable](https://github.com/flathub/com.discordapp.Discord/issues/621) on older distros, like RHEL 8, and since there's no counterpart launch option for disabling Speech Dispatcher, users of affected distros are stuck with a broken app.

Fixes #621