### PR TITLE
Create installation directory before running the bootstrapper

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -36,6 +36,7 @@ fi
 if [ ! -x "${XDG_CONFIG_HOME}/discord/Discord" ]
 then
     echo 'Missing symlink created by Discord after installation, running updater_bootstrap first...' >&2
+    mkdir -p "${XDG_CONFIG_HOME}/discord"
     app_dir=$(updater_bootstrap --zenity "${XDG_CONFIG_HOME}/discord" stable https://updates.discord.com/)
     if [ $? -eq 0 ]
     then


### PR DESCRIPTION
Otherwise it fails to install the client on a clean prefix:

```
$ mv ~/.var/app/com.discordapp.Discord{,.bak}
$ flatpak run com.discordapp.Discord
Missing symlink created by Discord after installation, running update_bootstrapper first...
Error: Other(unable to open database file: /home/user/.var/app/com.discordapp.Discord/config/discord/installer.db
Caused by:
    Error code 14: Unable to open the database file)
```