### PR TITLE
Stop patching `app.asar`

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -38,11 +38,6 @@ then
     echo 'Missing symlink created by Discord after installation, running updater_bootstrap first...' >&2
     mkdir -p "${XDG_CONFIG_HOME}/discord"
     app_dir=$(updater_bootstrap --zenity "${XDG_CONFIG_HOME}/discord" stable https://updates.discord.com/)
-    if [ $? -eq 0 ]
-    then
-        echo "Patching desktop file in Discord's asar file..." >&2
-        patch-electron-desktop-filename "${XDG_CONFIG_HOME}/discord/${app_dir}/resources/app.asar"
-    fi
 fi
 
 env TMPDIR="${XDG_CACHE_HOME}" ZYPAK_DISABLE_SANDBOX=1 zypak-wrapper "${XDG_CONFIG_HOME}/discord/${app_dir:-}/Discord" "${FLAGS[@]}" "$@"


### PR DESCRIPTION
While patching the `app.asar` is [recommended by the Flatpak documentation](https://docs.flatpak.org/en/latest/electron.html#using-correct-desktop-file-name) to fix some potential visual bugs, Discord's new built-in updater seems to check for the original hash of app.asar, and upon failing the hash check, it _supposedly_ leave some users with a broken installation (see #632, more specifically https://github.com/flathub/com.discordapp.Discord/issues/632#issuecomment-4457886528).

This isn't 100% confirmed yet (as I personally never had the issue), but we will stop patching the file for now, and see if the problem goes away for affected users with the next Discord update.