### PR TITLE
Invoke Discord with `--no-sandbox` explicitly

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -40,7 +40,7 @@ then
     app_dir=$(updater_bootstrap --zenity "${XDG_CONFIG_HOME}/discord" stable https://updates.discord.com/)
 fi
 
-env TMPDIR="${XDG_CACHE_HOME}" ZYPAK_DISABLE_SANDBOX=1 zypak-wrapper "${XDG_CONFIG_HOME}/discord/${app_dir:-}/Discord" "${FLAGS[@]}" "$@"
+env TMPDIR="${XDG_CACHE_HOME}" "${XDG_CONFIG_HOME}/discord/${app_dir:-}/Discord" --no-sandbox "${FLAGS[@]}" "$@"
 
 if [ "${invoke_socat}" = true ]
 then


### PR DESCRIPTION
Previously, we were delegating this task to zypak by setting `ZYPAK_DISABLE_SANDBOX=1`, but because it's currently broken anyway (see issue #624), we should probably just bypass it and use Chromium's `--no-sandbox` flag directly.

I'm hopeful this can also help Discord's internal updater to relaunch the client after a successful update (assuming it inherits the launch flags we set).