### PR TITLE
Fully package Discord (including its standalone modules)

### DIFF
--- a/com.discordapp.Discord.yaml
+++ b/com.discordapp.Discord.yaml
@@ -87,33 +87,154 @@ modules:
 
   - name: discord
     buildsystem: simple
+    build-options:
+      # Some Discord binary modules ship with debug symbols, make sure not to touch them.
+      no-debuginfo: true
+      strip: false
     build-commands:
+      - mkdir -p /app/discord/modules
+      # Extract the main Discord application
+      - brotli -cd discord.tar.br | tar xf - -C /app/discord --strip-components 1
+      # Extract Discord modules
+      - |
+        set -euo pipefail
+        for module in *_module.tar.br; do
+          target_dir=/app/discord/modules/${module%_*}
+          mkdir -p $target_dir
+          brotli -cdv -- $module | tar -xf - -C $target_dir --strip-components 1
+        done
       - install -Dm755 discord.sh /app/bin/com.discordapp.Discord
-      - install -Dm755 updater_bootstrap /app/bin
-      - install -Dm644 discord.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm755 disable-breaking-updates.py /app/bin
+      - install -Dm644 Discord/discord.desktop /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 com.discordapp.Discord.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm644 com.discordapp.Discord.appdata.xml /app/share/appdata/com.discordapp.Discord.appdata.xml
     post-install:
+      # HACK: Krisp fails to initialize if this directory is not present (or if can't be created). Logs:
+      #       MediaEngineStore] Failed to load Krisp module: Failed to setup Krisp module, error code: -4
+      #       [AVError] AV error reported: noise-canceller-error {"underlyingError":"NoiseCancellerError.KRISP_INIT_ERROR_GLOBAL_INIT"}
+      - mkdir -p /app/discord/modules/discord_krisp/KMS/logs
+      # HACK: Set the newUpdater key to false in build_info.json in order to disable the new Discord updater (released on 2026-05-04, version 1.0.136),
+      #       Also add a localModulesRoot key that points to the Discord modules we're packaging.
+      - |
+        set -e
+        jq '.newUpdater = false | .localModulesRoot = "/app/discord/modules"' /app/discord/resources/build_info.json > tmp.json
+        mv tmp.json /app/discord/resources/build_info.json
+      # HACK: Patch Discord's app.asar to fix the desktop filename to avoid window association issues, as recommended by the Flatpak documentation:
+      #       https://docs.flatpak.org/en/latest/electron.html#using-correct-desktop-file-name
+      - patch-electron-desktop-filename /app/discord/resources/app.asar
       - desktop-file-edit --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop
       - desktop-file-edit --set-key=Exec --set-value='com.discordapp.Discord %U' /app/share/applications/${FLATPAK_ID}.desktop
       - desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord /app/share/applications/${FLATPAK_ID}.desktop
       - desktop-file-edit --remove-key=Path /app/share/applications/${FLATPAK_ID}.desktop
     sources:
+      - type: file
+        dest-filename: discord.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/full.distro
+        sha256: deb0980d68578ef791f90b47cfb7c303cb8a26dd53e12567f3c8b1f10dbe778d
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          timestamp-query: .pub_date
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/full.distro"'
+          is-main-source: true
       - type: archive
         dest-filename: discord.tar.gz
+        strip-components: 0
         url: https://dl.discordapp.net/apps/linux/1.0.139/discord-1.0.139.tar.gz
         sha256: 7eacf2f46af49ddf2258f74d7b92f5e0f71f6a75b169d5205f4a8679b435063f
         x-checker-data:
           type: json
           url: https://discord.com/api/updates/stable?platform=linux
           version-query: .name
-          timestamp-query: .pub_date
           url-query: '"https://dl.discordapp.net/apps/linux/\($version)/discord-\($version).tar.gz"'
-          is-main-source: true
+      - type: file
+        dest-filename: discord_desktop_core_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_desktop_core/1/full.distro
+        sha256: e0d0befade0351ad91a2baf4106aa0f4b7a26d33f9b6271ff6b88b3082750cc8
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_desktop_core/1/full.distro"'
+      # TODO: Figure out a way to properly check for updates for each Discord module listed below.
+      - type: file
+        dest-filename: discord_erlpack_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_erlpack/1/full.distro
+        sha256: 3f80341a901d8ec18ce2736976cf6d2bd9264e7663d85bb37f5355959fc0fe4d
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_erlpack/1/full.distro"'
+      - type: file
+        dest-filename: discord_game_utils_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_game_utils/1/full.distro
+        sha256: 97e828e4f55db4993342f108637ba06ad8c43ee20c69007134585dd1d2991d40
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_game_utils/1/full.distro"'
+      - type: file
+        dest-filename: discord_krisp_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_krisp/1/full.distro
+        sha256: 12f8698fc3254e047e802384c08c9d02f831e0e2fb34f4dc97f1e91a1140b394
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_krisp/1/full.distro"'
+      - type: file
+        dest-filename: discord_rpc_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_rpc/1/full.distro
+        sha256: e5d4882aa7fb0fbfd5238c93a2af95166fd299e5d8653990faabb31c301877e8
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_rpc/1/full.distro"'
+      - type: file
+        dest-filename: discord_spellcheck_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_spellcheck/1/full.distro
+        sha256: dd1131258e99bfa6444dd3aae3613364e86d6dde8298a6c2cb7977a77257487b
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_spellcheck/1/full.distro"'
+      - type: file
+        dest-filename: discord_utils_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_utils/1/full.distro
+        sha256: 49a5224a75d71af40d03ab8e748dd6b36321bb64e3ee5152d93f30da670598da
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_utils/1/full.distro"'
+      - type: file
+        dest-filename: discord_voice_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_voice/1/full.distro
+        sha256: abaacf163deafc09bd7e1b287fd68316ac2c90b6be6464bf53b048d1f5e24b92
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_voice/1/full.distro"'
+      - type: file
+        dest-filename: discord_zstd_module.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_zstd/1/full.distro
+        sha256: 62510eaf144e93967a79b7837849410513e8c53e43cfc2b7c5e7e1396fd9b332
+        x-checker-data:
+          type: json
+          url: https://discord.com/api/updates/stable?platform=linux
+          version-query: .name
+          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_zstd/1/full.distro"'
       - type: file
         path: discord.sh
       - type: file
         path: com.discordapp.Discord.appdata.xml
       - type: file
         path: com.discordapp.Discord.svg
-
+      - type: file
+        path: disable-breaking-updates.py

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Disable breaking updates which will prompt users to download a deb or tar file
+and lock them out of Discord making the program unusable.
+
+This will dramatically improve the experience :
+
+ 1) The maintainer doesn't need to be worried at all times of an update which will break Discord.
+ 2) People will not be locked out of the program while the maintainer runs to update it.
+
+"""
+
+import json
+import os
+from pathlib import Path
+
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+    os.path.expanduser("~"), ".config"
+)
+
+settings_path = Path(f"{XDG_CONFIG_HOME}/discord/settings.json")
+settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
+try:
+    with settings_path.open() as settings_file:
+        settings = json.load(settings_file)
+except (IOError, json.decoder.JSONDecodeError):
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings = {}
+
+if settings.get("SKIP_HOST_UPDATE") and settings.get("SKIP_MODULE_UPDATE"):
+    print("Disabling updates already done")
+else:
+    skip_updates = {"SKIP_HOST_UPDATE":True, "SKIP_MODULE_UPDATE":True}
+    settings.update(skip_updates)
+
+    with settings_path_temp.open('w') as settings_file_temp:
+        json.dump(settings, settings_file_temp, indent=2)
+
+    settings_path_temp.rename(settings_path)
+    print("Disabled updates")
+

--- a/discord.sh
+++ b/discord.sh
@@ -32,15 +32,10 @@ then
     mapfile -t FLAGS <<< "$(grep -Ev '^\s*$|^#' "${XDG_CONFIG_HOME}/discord-flags.conf")"
 fi
 
-# Run the updater if we're missing a symlink to Discord's main binary in $XDG_CONFIG_HOME/discord
-if [ ! -x "${XDG_CONFIG_HOME}/discord/Discord" ]
-then
-    echo 'Missing symlink created by Discord after installation, running updater_bootstrap first...' >&2
-    mkdir -p "${XDG_CONFIG_HOME}/discord"
-    app_dir=$(updater_bootstrap --zenity "${XDG_CONFIG_HOME}/discord" stable https://updates.discord.com/)
-fi
+# Disable auto-updates for Discord and its modules.
+disable-breaking-updates.py
 
-env TMPDIR="${XDG_CACHE_HOME}" ZYPAK_DISABLE_SANDBOX=1 zypak-wrapper "${XDG_CONFIG_HOME}/discord/${app_dir:-}/Discord" "${FLAGS[@]}" "$@"
+env TMPDIR="${XDG_CACHE_HOME}" zypak-wrapper /app/discord/Discord "${FLAGS[@]}" "$@"
 
 if [ "${invoke_socat}" = true ]
 then


### PR DESCRIPTION
Before the 1.0.136 release (on 2026-05-04), we were packaging the main Discord application in full (except Discord's  modules, which are updated separately from the main application) to a read-only directory (`/app/discord`). This way of packaging Discord was good, mainly because we could easily downgrade to a previous version when breakage occurred (see #483).

With the 1.0.136 release, however, [Discord introduced a bootstrapper](https://discord.com/blog/discord-patch-notes-may-4-2026), which is meant to install _and_ update Discord independently from Flathub updates (just like the Steam client works). For this setup to work properly, Discord must be initially bootstrapped to a writable directory, like `$XDG_CONFIG_HOME/discord`.

This move was not a bad thing, but unfortunately we've received quite a few bug reports after it was implemented:

- Zypak stopped working, so the Chromium sandbox had to be disabled (#624)
- Quite a few users were ending up with broken installations (#626, #627, #632, #633)
- We had to stop patching Discord's `app.asar` to fix the desktop filename, because it would cause hash mismatch upon installing updates (#635)
- Even after a successful update, the bootstrapper could not launch the new version immediately because it would run without the `--no-sandbox` launch flag (https://github.com/flathub/com.discordapp.Discord/pull/640#issuecomment-4523076593)

To be fair, these issues could be 100% on us, but the second issue in particular is a very bad one, because it leaves users with a broken installation. and I can't reproduce it locally...

For those reasons, this PR now packages Discord "in full", like before, and it also includes the standalone modules for a "fully offline" installation that isn't managed by the new Discord bootstrapper.

To be completely honest, some of the things I'm doing here might be very hacky and/or for Discord developers only, so this whole thing could crumble at any time.

Still, I made sure to verify that some of the most used features (based on data I made up) still work, like sending messages, voice chat, screen sharing, files uploads. Obviously, I can't test every single feature Discord has, so I'm also relying on (future) user feedback.

For now, though, I genuinely think we're improving on the status quo.

Closes #624
Closes #632