### PR TITLE
Add external data checker info for Discord modules

### DIFF
--- a/com.discordapp.Discord.yaml
+++ b/com.discordapp.Discord.yaml
@@ -127,109 +127,117 @@ modules:
       - desktop-file-edit --set-key=Icon --set-value=com.discordapp.Discord /app/share/applications/${FLATPAK_ID}.desktop
       - desktop-file-edit --remove-key=Path /app/share/applications/${FLATPAK_ID}.desktop
     sources:
-      - type: file
-        dest-filename: discord.tar.br
-        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/full.distro
-        sha256: deb0980d68578ef791f90b47cfb7c303cb8a26dd53e12567f3c8b1f10dbe778d
-        x-checker-data:
-          type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          timestamp-query: .pub_date
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/full.distro"'
-          is-main-source: true
       - type: archive
         dest-filename: discord.tar.gz
         strip-components: 0
         url: https://dl.discordapp.net/apps/linux/1.0.139/discord-1.0.139.tar.gz
         sha256: 7eacf2f46af49ddf2258f74d7b92f5e0f71f6a75b169d5205f4a8679b435063f
         x-checker-data:
+          is-main-source: true
           type: json
           url: https://discord.com/api/updates/stable?platform=linux
           version-query: .name
+          timestamp-query: .pub_date
           url-query: '"https://dl.discordapp.net/apps/linux/\($version)/discord-\($version).tar.gz"'
+      - type: file
+        dest-filename: discord.tar.br
+        url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/full.distro
+        sha256: deb0980d68578ef791f90b47cfb7c303cb8a26dd53e12567f3c8b1f10dbe778d
+        x-checker-data:
+          type: json
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .full.host_version | map(tostring) | join(".")
+          url-query: .full.url
       - type: file
         dest-filename: discord_desktop_core_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_desktop_core/1/full.distro
         sha256: e0d0befade0351ad91a2baf4106aa0f4b7a26d33f9b6271ff6b88b3082750cc8
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_desktop_core/1/full.distro"'
-      # TODO: Figure out a way to properly check for updates for each Discord module listed below.
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_desktop_core.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_desktop_core.full.url
       - type: file
         dest-filename: discord_erlpack_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_erlpack/1/full.distro
         sha256: 3f80341a901d8ec18ce2736976cf6d2bd9264e7663d85bb37f5355959fc0fe4d
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_erlpack/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_erlpack.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_erlpack.full.url
       - type: file
         dest-filename: discord_game_utils_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_game_utils/1/full.distro
         sha256: 97e828e4f55db4993342f108637ba06ad8c43ee20c69007134585dd1d2991d40
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_game_utils/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_game_utils.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_game_utils.full.url
       - type: file
         dest-filename: discord_krisp_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_krisp/1/full.distro
         sha256: 12f8698fc3254e047e802384c08c9d02f831e0e2fb34f4dc97f1e91a1140b394
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_krisp/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_krisp.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_krisp.full.url
       - type: file
         dest-filename: discord_rpc_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_rpc/1/full.distro
         sha256: e5d4882aa7fb0fbfd5238c93a2af95166fd299e5d8653990faabb31c301877e8
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_rpc/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_rpc.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_rpc.full.url
       - type: file
         dest-filename: discord_spellcheck_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_spellcheck/1/full.distro
         sha256: dd1131258e99bfa6444dd3aae3613364e86d6dde8298a6c2cb7977a77257487b
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_spellcheck/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_spellcheck.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_spellcheck.full.url
       - type: file
         dest-filename: discord_utils_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_utils/1/full.distro
         sha256: 49a5224a75d71af40d03ab8e748dd6b36321bb64e3ee5152d93f30da670598da
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_utils/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_utils.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_utils.full.url
       - type: file
         dest-filename: discord_voice_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_voice/1/full.distro
         sha256: abaacf163deafc09bd7e1b287fd68316ac2c90b6be6464bf53b048d1f5e24b92
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_voice/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_voice.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_voice.full.url
       - type: file
         dest-filename: discord_zstd_module.tar.br
         url: https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.139/discord_zstd/1/full.distro
         sha256: 62510eaf144e93967a79b7837849410513e8c53e43cfc2b7c5e7e1396fd9b332
         x-checker-data:
           type: json
-          url: https://discord.com/api/updates/stable?platform=linux
-          version-query: .name
-          url-query: '"https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/\($version)/discord_zstd/1/full.distro"'
+          url: https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64
+          version-query: .modules.discord_zstd.full | "\(.host_version | map(tostring)
+            | join("."))-\(.module_version)"
+          url-query: .modules.discord_zstd.full.url
       - type: file
         path: discord.sh
       - type: file


### PR DESCRIPTION
This should keep them always up to date.

I'll still need to manually check for added or removed modules, however:

```
curl -s 'https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=linux&arch=x64' | jq -r '(.modules | to_entries | sort_by(.key)[] | "\(.key): \(.value.full.host_version | map(tostring) | join("."))-\(.value.full.module_version)"), ("required modules: \(.required_modules | join(", "))")'
```