### PR TITLE
Drop unused UPower permission

### DIFF
--- a/com.discordapp.Discord.yaml
+++ b/com.discordapp.Discord.yaml
@@ -26,7 +26,6 @@ finish-args:
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.indicator.application
   - --talk-name=com.canonical.Unity
-  - --system-talk-name=org.freedesktop.UPower
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --env=ELECTRON_TRASH=gio
 


### PR DESCRIPTION
This was added by me in commit 5e0efe43d6e205a343c8cebc3a0ce05d78a557ee, back in 2024, but the error message mentioned in the commit is now gone and Discord is able to inhibit screen locking just fine without it:

<img width="656" height="414" alt="image" src="https://github.com/user-attachments/assets/6403d2d6-7ec6-481a-8e79-2bd1d7c95744" />
