### PR TITLE
Fix black camera with video backgrounds (MediaPipe O_RDWR on read-only /app)

### DIFF
--- a/com.discordapp.Discord.yaml
+++ b/com.discordapp.Discord.yaml
@@ -118,6 +118,25 @@ modules:
         set -e
         jq '.newUpdater = false | .localModulesRoot = "/app/discord/modules"' /app/discord/resources/build_info.json > tmp.json
         mv tmp.json /app/discord/resources/build_info.json
+      # HACK: MediaPipe (video backgrounds / selfie segmentation) opens discord_voice *.tflite
+      #       models with O_RDWR. /app is mounted read-only, so the open fails with EACCES and the
+      #       camera goes black (see https://github.com/flathub/com.discordapp.Discord/issues/650).
+      #       Flatpak cannot ship files into the per-user writable tree at build time (/var/data is
+      #       created empty at runtime), so stash the real models under /app and replace them in the
+      #       module dir with symlinks to /var/data/mediapipe_models; discord.sh copies the stash
+      #       there on launch. Globbing *.tflite picks up any models Discord adds later.
+      - |
+        set -eu
+        voice=/app/discord/modules/discord_voice
+        store=/app/discord/mediapipe_models
+        # /var/data is Flatpak's alias for $XDG_DATA_HOME; keep an absolute path in the symlink.
+        writable=/var/data/mediapipe_models
+        mkdir -p "${store}"
+        for model in "${voice}"/*.tflite; do
+          name=${model##*/}
+          mv -f "${model}" "${store}/${name}"
+          ln -sfn "${writable}/${name}" "${voice}/${name}"
+        done
       # HACK: Patch Discord's app.asar to fix the desktop filename to avoid window association issues, as recommended by the Flatpak documentation:
       #       https://docs.flatpak.org/en/latest/electron.html#using-correct-desktop-file-name
       - patch-electron-desktop-filename /app/discord/resources/app.asar

--- a/discord.sh
+++ b/discord.sh
@@ -35,6 +35,24 @@ fi
 # Disable auto-updates for Discord and its modules.
 disable-breaking-updates.py
 
+# Seed writable copies of MediaPipe *.tflite models (symlinked from /app at build;
+# see com.discordapp.Discord.yaml).
+# Destination matches the build-time symlink target (/var/data == $XDG_DATA_HOME here).
+# See: https://github.com/flathub/com.discordapp.Discord/issues/650
+mediapipe_store=/app/discord/mediapipe_models
+mediapipe_models="${XDG_DATA_HOME:-/var/data}/mediapipe_models"
+if [ ! -d "${mediapipe_models}" ]
+then
+    mkdir -p "${mediapipe_models}"
+fi
+for model in "${mediapipe_store}"/*.tflite
+do
+    if ! cmp -s "${model}" "${mediapipe_models}/${model##*/}"
+    then
+        cp "${model}" "${mediapipe_models}"
+    fi
+done
+
 env TMPDIR="${XDG_CACHE_HOME}" zypak-wrapper /app/discord/Discord "${FLAGS[@]}" "$@"
 
 if [ "${invoke_socat}" = true ]


### PR DESCRIPTION
## Summary

Enabling a video background (selfie segmentation) currently produces an all-black camera. MediaPipe opens the sibling `selfie_segmentation*.tflite` files with `O_RDWR`. Because `/app` is mounted read-only, those opens fail with `EACCES` and the segmentation graph errors:

```
Failed to load resource: mediapipe/modules/selfie_segmentation/selfie_segmentation_landscape.tflite
```

Fixes #650.

## Change

Modules stay in read-only `/app` (`localModulesRoot` unchanged). Only the `discord_voice` `*.tflite` models need to be writable:

- **Build:** stash every `*.tflite` under `/app/discord/mediapipe_models` and replace them in the module directory with symlinks to `/var/data/mediapipe_models` (per-user `$XDG_DATA_HOME/mediapipe_models`).
- **Launch:** `discord.sh` copies the stash into `/var/data/mediapipe_models` (~500 KB; refreshed each start so Flatpak updates are picked up).

Globbing `*.tflite` means new MediaPipe models in future Discord module updates are handled without naming them.

## Notes

- Flatpak cannot ship files into `/var/data` at build time (that tree is created empty per user), so a small launcher seed is required alongside the build-time symlinks.
- Native code (`discord_voice.node`, `libmediapipe.so`) still loads from read-only `/app`.

## Testing

Built with flatpak-builder, installed in user scope (normal `zypak-wrapper`/sandbox path). Verified the models are `O_RDWR`-openable through the symlinks and that video backgrounds render without the `EACCES` / `Failed to load resource` errors.

Made with [Cursor](https://cursor.com)